### PR TITLE
fix: Docker default startup crash + env-var auth support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,22 @@
 # Run server on loopback (safe default, no auth required):
 #   docker run -it amcp serve
 #
-# Run server exposed to the host network with authentication:
+# Run server exposed to the host network with authentication (via env vars):
+#   docker run -p 8080:8080 \
+#       -e AMCP_HOST=0.0.0.0 -e AMCP_API_KEY=your-secret \
+#       amcp serve
+#
+# Run server exposed to the host network with authentication (via config file):
 #   docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
 #       amcp serve --host 0.0.0.0
 #
 # With scheduler & reactor:
-#   docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
-#       amcp serve --host 0.0.0.0 --scheduler --reactor
+#   docker run -p 8080:8080 \
+#       -e AMCP_HOST=0.0.0.0 -e AMCP_API_KEY=your-secret \
+#       amcp serve --scheduler --reactor
 #
-# NOTE: A non-loopback --host (e.g. 0.0.0.0) requires [server.auth] to be
-#       configured. Bind to loopback for unauthenticated use.
+# NOTE: A non-loopback --host (e.g. 0.0.0.0) requires authentication.
+#       Use --api-key, AMCP_API_KEY env var, or [server.auth] in config.toml.
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,22 @@
 # Build:
 #   docker build -t amcp .
 #
-# Run:
-#   docker run -p 8080:8080 amcp
-#   docker run -p 8080:8080 -v /path/to/project:/workspace amcp \
-#       serve --host 0.0.0.0 --work-dir /workspace
+# Run (interactive CLI inside the container):
+#   docker run -it amcp
+#
+# Run server on loopback (safe default, no auth required):
+#   docker run -it amcp serve
+#
+# Run server exposed to the host network with authentication:
+#   docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
+#       amcp serve --host 0.0.0.0
 #
 # With scheduler & reactor:
 #   docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
 #       amcp serve --host 0.0.0.0 --scheduler --reactor
+#
+# NOTE: A non-loopback --host (e.g. 0.0.0.0) requires [server.auth] to be
+#       configured. Bind to loopback for unauthenticated use.
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
@@ -51,4 +59,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/bin/tini", "--", "amcp"]
-CMD ["serve", "--host", "0.0.0.0"]
+CMD ["serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@
 #
 # NOTE: A non-loopback --host (e.g. 0.0.0.0) requires authentication.
 #       Use --api-key, AMCP_API_KEY env var, or [server.auth] in config.toml.
+#       Custom ports via AMCP_PORT are picked up by the HEALTHCHECK automatically.
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
@@ -60,7 +61,7 @@ WORKDIR /workspace
 
 # Health check — hits the server /api/v1/health endpoint
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/api/v1/health')" || exit 1
+    CMD python -c "import os,urllib.request; urllib.request.urlopen('http://localhost:%s/api/v1/health' % os.environ.get('AMCP_PORT', '8080'))" || exit 1
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -239,10 +239,17 @@ docker build -t amcp .
 docker run -it amcp serve          # loopback:8080, no auth needed
 ```
 
-To expose the server on the host network, configure authentication and bind to `0.0.0.0`:
+To expose the server on the host network, provide an API key via environment variables:
 
 ```bash
-# Create a config.toml with [server.auth] enabled and an api_key set
+docker run -p 8080:8080 \
+    -e AMCP_HOST=0.0.0.0 -e AMCP_API_KEY=your-secret \
+    amcp serve
+```
+
+Alternatively, mount a `config.toml` with `[server.auth]` enabled:
+
+```bash
 docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
     amcp serve --host 0.0.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -230,6 +230,31 @@ Authenticated CLI clients can pass `--api-key` or set `AMCP_SERVER_API_KEY`. HTT
 `Authorization: Bearer <api-key>`; WebSocket clients may use the same header. The health endpoint
 remains public for probes.
 
+### Docker
+
+The default Docker command starts the server on loopback — safe without authentication:
+
+```bash
+docker build -t amcp .
+docker run -it amcp serve          # loopback:8080, no auth needed
+```
+
+To expose the server on the host network, configure authentication and bind to `0.0.0.0`:
+
+```bash
+# Create a config.toml with [server.auth] enabled and an api_key set
+docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
+    amcp serve --host 0.0.0.0
+```
+
+The health check (`GET /api/v1/health`) always remains public for container orchestration probes.
+For interactive CLI usage inside a container without starting the server:
+
+```bash
+docker run -it amcp --once "explain this codebase"
+```
+
+
 ### Durable execution timeline
 
 AMCP stores a bounded per-session timeline beside each session snapshot. It records turn, tool,

--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ For interactive CLI usage inside a container without starting the server:
 docker run -it amcp --once "explain this codebase"
 ```
 
-
 ### Durable execution timeline
 
 AMCP stores a bounded per-session timeline beside each session snapshot. It records turn, tool,

--- a/src/amcp/cli.py
+++ b/src/amcp/cli.py
@@ -238,12 +238,30 @@ def telegram_setup() -> None:
 def serve_command(
     host: Annotated[
         str,
-        typer.Option("--host", "-H", help="Host to bind the server to"),
+        typer.Option(
+            "--host",
+            "-H",
+            envvar="AMCP_HOST",
+            help="Host to bind the server to (env: AMCP_HOST)",
+        ),
     ] = "127.0.0.1",
     port: Annotated[
         int,
-        typer.Option("--port", "-p", help="Port to listen on"),
+        typer.Option(
+            "--port",
+            "-p",
+            envvar="AMCP_PORT",
+            help="Port to listen on (env: AMCP_PORT)",
+        ),
     ] = 8080,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            envvar="AMCP_API_KEY",
+            help="Enable server authentication with this API key (env: AMCP_API_KEY)",
+        ),
+    ] = None,
     work_dir: Annotated[
         Path | None,
         typer.Option(
@@ -273,8 +291,9 @@ def serve_command(
     Examples:
         amcp serve                          # Start on localhost:8080
         amcp serve --port 8080             # Use custom port
-        amcp serve --host 0.0.0.0          # Listen on all interfaces
+        amcp serve --host 0.0.0.0 --api-key s3cret  # Listen on all interfaces
         amcp serve -w /path/to/project     # Set default working directory
+        AMCP_HOST=0.0.0.0 AMCP_API_KEY=... amcp serve  # Same via env vars
 
     API Documentation:
         Once running, visit http://localhost:8080/docs for API docs.
@@ -289,14 +308,15 @@ def serve_command(
 
     cfg = load_config()
     configured_auth = cfg.server.auth if cfg.server else None
-    runtime_auth = (
-        RuntimeAuthConfig(
+    if api_key:
+        runtime_auth = RuntimeAuthConfig(enabled=True, api_key=api_key)
+    elif configured_auth:
+        runtime_auth = RuntimeAuthConfig(
             enabled=configured_auth.enabled,
             api_key=configured_auth.api_key,
         )
-        if configured_auth
-        else RuntimeAuthConfig()
-    )
+    else:
+        runtime_auth = RuntimeAuthConfig()
 
     if telegram_enabled:
         _start_telegram_bot(work_dir)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -668,3 +668,53 @@ class TestConflictStrategy:
         data = response.json()
         assert data["status"] == "complete"
         assert data["response"] == "reject strategy response"
+
+
+class TestServeEnvVars:
+    """Test serve command env-var and flag handling for host/port/api-key."""
+
+    def test_env_vars_recognized_in_help(self):
+        """Typer exposes AMCP_HOST/AMCP_PORT/AMCP_API_KEY as envvar options."""
+        from typer.testing import CliRunner
+
+        from amcp.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["serve", "--help"])
+        assert result.exit_code == 0
+        assert "AMCP_HOST" in result.output
+        assert "AMCP_PORT" in result.output
+        assert "AMCP_API_KEY" in result.output
+
+    def test_api_key_flag_enables_auth(self):
+        """--api-key CLI flag builds ServerConfig with auth enabled."""
+        from amcp.cli import serve_command
+        from amcp.server.config import AuthConfig
+
+        original_run = None
+
+        captured: dict = {}
+
+        def fake_run_server(**kwargs):
+            captured.update(kwargs)
+
+        import amcp.server
+
+        original_run = amcp.server.run_server
+        amcp.server.run_server = fake_run_server
+        try:
+            serve_command(
+                host="0.0.0.0",
+                port=8080,
+                api_key="flag-secret",
+                work_dir=None,
+                reload=False,
+                telegram_enabled=False,
+            )
+        finally:
+            amcp.server.run_server = original_run
+
+        auth = captured.get("auth")
+        assert auth is not None
+        assert auth.enabled is True
+        assert auth.api_key == "flag-secret"


### PR DESCRIPTION
## Problem

`docker run -p 8080:8080 amcp` crashes on startup because the Dockerfile `CMD ["serve", "--host", "0.0.0.0"]` conflicts with `ServerConfig.validate_security()`, which rejects non-loopback binds without authentication.

## Changes

**1. Dockerfile: `CMD ["serve"]` (loopback default)**
- Removes `--host 0.0.0.0` so unauthenticated startup succeeds
- Updated header comments with all run patterns

**2. `serve` command: env-var support**
- `AMCP_HOST` → `--host` (env: `AMCP_HOST`)
- `AMCP_PORT` → `--port` (env: `AMCP_PORT`)
- `AMCP_API_KEY` → `--api-key` (env: `AMCP_API_KEY`) — auto-enables auth when set
- Priority: CLI flag / env var > `config.toml [server.auth]`

**3. README: Docker section**
- Documents all three deployment patterns

## Usage

```bash
# Default — loopback, no auth needed
docker run -it amcp serve

# Env-var auth (Docker-friendly, no config mount)
docker run -p 8080:8080 \
    -e AMCP_HOST=0.0.0.0 -e AMCP_API_KEY=your-secret \
    amcp serve

# Config-file auth
docker run -p 8080:8080 -v ./config.toml:/root/.config/amcp/config.toml \
    amcp serve --host 0.0.0.0
```

## Verification

- Docker image built and tested:
  - Default `serve` → starts on 127.0.0.1:8080, health check 200 ✅
  - `AMCP_HOST=0.0.0.0 AMCP_API_KEY=test` → health public 200, unauthenticated 401, authenticated 200 ✅
  - `--host 0.0.0.0` without auth → clear `ValueError` ✅
- 80 server/config tests pass ✅