### PR TITLE
refactor: rename config/project dirs to ankaloop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ Thumbs.db
 *.pid
 *.seed
 *.pid.lock
+.ankaloop/memory/
 .amcp/memory/
 e2b/
 e2b.toml

--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ Run `anka --help` or `anka <command> --help` for the complete command reference.
 
 ## Configuration
 
-Run `anka init` for the interactive provider wizard. AnkaLoop currently keeps configuration in
-`~/.config/amcp/config.toml`; this legacy path is retained for compatibility during the rebrand.
+Run `anka init` for the interactive provider wizard. Configuration lives in
+`~/.config/ankaloop/config.toml`. Set `ANKA_CONFIG_DIR_NAME=amcp` to keep the legacy
+`~/.config/amcp/` path from pre-rebrand deployments.
 
 ### OpenAI-compatible endpoint
 
@@ -236,10 +237,10 @@ independent work to subagents.
   and file references.
 - **Hooks** validate, modify, block, or audit tool calls before and after execution.
 
-Project extensions currently live under `.amcp/` for compatibility:
+Project extensions live under `.ankaloop/`:
 
 ```text
-.amcp/
+.ankaloop/
 ├── commands/       # TOML slash commands
 ├── hooks.toml      # pre/post tool hooks
 ├── memory/         # project knowledge

--- a/deploy-gmi/Dockerfile
+++ b/deploy-gmi/Dockerfile
@@ -31,7 +31,7 @@ RUN uv sync --frozen --no-dev --no-editable --extra telegram
 
 COPY deploy-gmi/gmi-entrypoint.sh /usr/local/bin/gmi-entrypoint
 RUN chmod +x /usr/local/bin/gmi-entrypoint \
-    && mkdir -p /workspace/.config/amcp
+    && mkdir -p /workspace/.config/ankaloop
 
 WORKDIR /workspace
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ Agent specifications define the behavior, capabilities, and system prompts for d
 
 1. **Copy an agent spec to your project:**
    ```bash
-   cp examples/agents/web-developer.yaml ~/.config/amcp/agents/
+   cp examples/agents/web-developer.yaml ~/.config/ankaloop/agents/
    ```
 
 2. **Use the agent with AnkaLoop:**
@@ -80,11 +80,11 @@ Slash commands provide quick shortcuts for common tasks. These examples demonstr
 1. **Copy commands to your configuration:**
    ```bash
    # User-level commands
-   cp examples/commands/*.toml ~/.config/amcp/commands/
+   cp examples/commands/*.toml ~/.config/ankaloop/commands/
 
    # Project-level commands
-   mkdir -p .amcp/commands
-   cp examples/commands/*.toml .amcp/commands/
+   mkdir -p .ankaloop/commands
+   cp examples/commands/*.toml .ankaloop/commands/
    ```
 
 2. **Use commands in AnkaLoop:**
@@ -127,11 +127,11 @@ Skills provide specialized knowledge and behavior patterns to agents. These exam
 1. **Copy skills to your configuration:**
    ```bash
    # User-level skills
-   cp -r examples/skills/* ~/.config/amcp/skills/
+   cp -r examples/skills/* ~/.config/ankaloop/skills/
 
    # Project-level skills
-   mkdir -p .amcp/skills
-   cp -r examples/skills/* .amcp/skills/
+   mkdir -p .ankaloop/skills
+   cp -r examples/skills/* .ankaloop/skills/
    ```
 
 2. **Activate skills in your agent or during conversation:**
@@ -184,9 +184,9 @@ Hooks provide automation and validation capabilities that run at various points 
 
 1. **Copy hook configuration:**
    ```bash
-   cp examples/hooks/automated-testing.toml ~/.config/amcp/hooks.toml
+   cp examples/hooks/automated-testing.toml ~/.config/ankaloop/hooks.toml
    # or for project-specific hooks
-   cp examples/hooks/automated-testing.toml .amcp/hooks.toml
+   cp examples/hooks/automated-testing.toml .ankaloop/hooks.toml
    ```
 
 2. **Make hook scripts executable:**
@@ -253,10 +253,10 @@ AnkaLoop> "Set up a CI/CD pipeline and ensure it meets security standards"
 2. **Copy examples to your configuration:**
    ```bash
    # Copy all examples
-   cp -r examples/agents/* ~/.config/amcp/agents/
-   cp -r examples/commands/* ~/.config/amcp/commands/
-   cp -r examples/skills/* ~/.config/amcp/skills/
-   cp examples/hooks/*.toml ~/.config/amcp/
+   cp -r examples/agents/* ~/.config/ankaloop/agents/
+   cp -r examples/commands/* ~/.config/ankaloop/commands/
+   cp -r examples/skills/* ~/.config/ankaloop/skills/
+   cp examples/hooks/*.toml ~/.config/ankaloop/
    ```
 
 3. **Start using AnkaLoop with examples:**
@@ -266,14 +266,14 @@ AnkaLoop> "Set up a CI/CD pipeline and ensure it meets security standards"
 
 ### Project-Specific Configuration
 
-For project-specific configurations, create a `.amcp` directory in your project root:
+For project-specific configurations, create a `.ankaloop` directory in your project root:
 
 ```bash
-mkdir -p .amcp/{agents,commands,skills}
-cp -r examples/agents/* .amcp/agents/
-cp -r examples/commands/* .amcp/commands/
-cp -r examples/skills/* .amcp/skills/
-cp examples/hooks.toml .amcp/
+mkdir -p .ankaloop/{agents,commands,skills}
+cp -r examples/agents/* .ankaloop/agents/
+cp -r examples/commands/* .ankaloop/commands/
+cp -r examples/skills/* .ankaloop/skills/
+cp examples/hooks.toml .ankaloop/
 ```
 
 ## 📚 Best Practices

--- a/examples/hooks/automated-testing.toml
+++ b/examples/hooks/automated-testing.toml
@@ -1,6 +1,6 @@
 # Automated Testing Hooks Configuration
 # This file demonstrates hooks for automated testing and quality assurance
-# Copy this file to .amcp/hooks.toml in your project to enable
+# Copy this file to .ankaloop/hooks.toml in your project to enable
 
 # PreToolUse hooks - run before tool execution
 [hooks.PreToolUse]

--- a/examples/hooks/hooks.toml
+++ b/examples/hooks/hooks.toml
@@ -1,6 +1,6 @@
-# AMCP Hooks Configuration Example
-# This file should be placed at .amcp/hooks.toml in your project directory
-# or ~/.config/amcp/hooks.toml for user-level hooks
+# AnkaLoop Hooks Configuration Example
+# This file should be placed at .ankaloop/hooks.toml in your project directory
+# or ~/.config/ankaloop/hooks.toml for user-level hooks
 
 # PreToolUse hooks - run before tool execution
 [hooks.PreToolUse]

--- a/examples/hooks/scripts/log_tool_calls.py
+++ b/examples/hooks/scripts/log_tool_calls.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 def log_tool_call(hook_data: dict):
     """Log tool call information."""
-    log_dir = Path.home() / ".amcp" / "logs"
+    log_dir = Path.home() / ".ankaloop" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     
     log_file = log_dir / f"tool_calls_{datetime.now().strftime('%Y-%m-%d')}.jsonl"

--- a/examples/hooks/security-validation.toml
+++ b/examples/hooks/security-validation.toml
@@ -1,6 +1,6 @@
 # Security Validation Hooks Configuration
 # This file demonstrates hooks for security validation and compliance
-# Copy this file to .amcp/hooks.toml in your project to enable
+# Copy this file to .ankaloop/hooks.toml in your project to enable
 
 # PreToolUse hooks - run before tool execution
 [hooks.PreToolUse]

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -25,12 +25,12 @@ Plugins can be shared across projects and teams, providing consistent tooling an
 
 1. **Copy plugin to your project:**
    ```bash
-   cp -r examples/plugins/feature-dev .amcp/plugins/
+   cp -r examples/plugins/feature-dev .ankaloop/plugins/
    ```
 
 2. **Or copy to user-level config:**
    ```bash
-   cp -r examples/plugins/feature-dev ~/.config/amcp/plugins/
+   cp -r examples/plugins/feature-dev ~/.config/ankaloop/plugins/
    ```
 
 3. **Use the plugin commands:**
@@ -63,7 +63,7 @@ plugin-name/
 ### 1. Create plugin directory
 
 ```bash
-mkdir -p .amcp/plugins/my-plugin/{commands,agents,skills,hooks}
+mkdir -p .ankaloop/plugins/my-plugin/{commands,agents,skills,hooks}
 ```
 
 ### 2. Add plugin.json
@@ -90,12 +90,12 @@ Create commands, agents, skills, or hooks as needed.
 ### 4. Test your plugin
 
 ```bash
-anka --plugin .amcp/plugins/my-plugin
+anka --plugin .ankaloop/plugins/my-plugin
 ```
 
 ## Plugin Configuration
 
-Plugins can be configured in your project's `.amcp/settings.json`:
+Plugins can be configured in your project's `.ankaloop/settings.json`:
 
 ```json
 {
@@ -103,8 +103,8 @@ Plugins can be configured in your project's `.amcp/settings.json`:
     "enabled": ["feature-dev", "code-review"],
     "disabled": ["security-guidance"],
     "paths": [
-      ".amcp/plugins",
-      "~/.config/amcp/plugins"
+      ".ankaloop/plugins",
+      "~/.config/ankaloop/plugins"
     ]
   }
 }

--- a/examples/plugins/security-guidance/README.md
+++ b/examples/plugins/security-guidance/README.md
@@ -82,17 +82,17 @@ Why this is dangerous and what to do instead.
 
 1. Copy to your project:
    ```bash
-   cp -r examples/plugins/security-guidance .amcp/plugins/
+   cp -r examples/plugins/security-guidance .ankaloop/plugins/
    ```
 
 2. Or copy to user config:
    ```bash
-   cp -r examples/plugins/security-guidance ~/.config/amcp/plugins/
+   cp -r examples/plugins/security-guidance ~/.config/ankaloop/plugins/
    ```
 
 ## Customization
 
-Create your own hooks in `.amcp/hooks/` or `.amcp/plugins/*/hooks/`:
+Create your own hooks in `.ankaloop/hooks/` or `.ankaloop/plugins/*/hooks/`:
 
 ```markdown
 ---

--- a/examples/workflows/data-science-workflow.md
+++ b/examples/workflows/data-science-workflow.md
@@ -281,7 +281,7 @@ Data Scientist: Perfect! Your customer churn prediction system is now complete w
 
 2. **Ensure supporting agents are available:**
    ```bash
-   cp examples/agents/documentation-writer.yaml ~/.config/amcp/agents/
+   cp examples/agents/documentation-writer.yaml ~/.config/ankaloop/agents/
    ```
 
 3. **Provide your dataset and requirements**

--- a/examples/workflows/devops-security-workflow.md
+++ b/examples/workflows/devops-security-workflow.md
@@ -406,8 +406,8 @@ DevOps Engineer: Perfect! Your secure CI/CD pipeline is now complete with all se
 
 2. **Ensure supporting agents are available:**
    ```bash
-   cp examples/agents/security-auditor.yaml ~/.config/amcp/agents/
-   cp examples/agents/documentation-writer.yaml ~/.config/amcp/agents/
+   cp examples/agents/security-auditor.yaml ~/.config/ankaloop/agents/
+   cp examples/agents/documentation-writer.yaml ~/.config/ankaloop/agents/
    ```
 
 3. **Provide your application requirements and security needs**

--- a/examples/workflows/web-development-workflow.md
+++ b/examples/workflows/web-development-workflow.md
@@ -176,8 +176,8 @@ Web Developer: Perfect! I've now integrated the security improvements and docume
 
 2. **Make sure other agents are available:**
    ```bash
-   cp examples/agents/security-auditor.yaml ~/.config/amcp/agents/
-   cp examples/agents/documentation-writer.yaml ~/.config/amcp/agents/
+   cp examples/agents/security-auditor.yaml ~/.config/ankaloop/agents/
+   cp examples/agents/documentation-writer.yaml ~/.config/ankaloop/agents/
    ```
 
 3. **Submit your request and let the agents collaborate!**

--- a/src/ankaloop/agent.py
+++ b/src/ankaloop/agent.py
@@ -26,6 +26,7 @@ from .compaction import (
     get_model_context_window,
 )
 from .config import AnkaloopConfig, ChatConfig, ContextConfig, ModelConfig, load_config
+from .constants import CONFIG_DIR_NAME
 from .context_builder import ContextBuilder
 from .hooks import run_post_tool_use_hooks, run_pre_tool_use_hooks, run_user_prompt_hooks
 from .llm import ContextOverflowError, ProviderError, classify_provider_error
@@ -190,7 +191,7 @@ class Agent:
         self._task_manager = TaskManager()
         self.conversation_history: list[dict[str, Any]] = []
         self._session_store = SessionStore(
-            Path.home() / ".config" / "amcp" / "sessions",
+            Path.home() / ".config" / CONFIG_DIR_NAME / "sessions",
             self.session_id,
         )
         self._timeline_store = SessionTimelineStore(

--- a/src/ankaloop/builtin_skills/skill-creator/scripts/init_skill.py
+++ b/src/ankaloop/builtin_skills/skill-creator/scripts/init_skill.py
@@ -5,8 +5,8 @@ Usage:
     python init_skill.py <skill-name> --path <output-directory> [--resources scripts,references,assets]
 
 Examples:
-    python init_skill.py my-skill --path .amcp/skills
-    python init_skill.py my-skill --path ~/.config/amcp/skills --resources scripts,references
+    python init_skill.py my-skill --path .ankaloop/skills
+    python init_skill.py my-skill --path ~/.config/ankaloop/skills --resources scripts,references
 """
 
 from __future__ import annotations

--- a/src/ankaloop/cli.py
+++ b/src/ankaloop/cli.py
@@ -29,6 +29,7 @@ from .config import (
     save_config,
     save_default_config,
 )
+from .constants import CONFIG_DIR_NAME
 from .mcp_client import call_mcp_tool, list_mcp_tools
 from .multi_agent import get_agent_registry
 from .skills import get_skill_manager
@@ -489,7 +490,7 @@ def _attach_sync(
     console.print()
 
     # Setup prompt
-    history_file = Path.home() / ".config" / "amcp" / "attach_history.txt"
+    history_file = Path.home() / ".config" / CONFIG_DIR_NAME / "attach_history.txt"
     history_file.parent.mkdir(parents=True, exist_ok=True)
     prompt_session: PromptSession[str] = PromptSession(history=FileHistory(str(history_file)))
 
@@ -782,7 +783,7 @@ def main(
 
     # Handle session listing
     if list_sessions:
-        sessions_dir = Path.home() / ".config" / "amcp" / "sessions"
+        sessions_dir = Path.home() / ".config" / CONFIG_DIR_NAME / "sessions"
         if not sessions_dir.exists():
             console.print("[yellow]No sessions directory found[/yellow]")
             return
@@ -811,7 +812,7 @@ def main(
 
     if list_agents:
         # Check both global config dir and local agents dir
-        agents_dir = Path(os.path.expanduser("~/.config/amcp/agents"))
+        agents_dir = Path(os.path.expanduser(f"~/.config/{CONFIG_DIR_NAME}/agents"))
         local_agents_dir = Path("agents")
 
         agent_files_list = list_available_agents(agents_dir)
@@ -822,7 +823,7 @@ def main(
 
         if not all_agent_files:
             console.print(
-                "[yellow]No agent specifications found. Create one in ~/.config/amcp/agents/ or local agents/[/yellow]"
+                "[yellow]No agent specifications found. Create one in ~/.config/ankaloop/agents/ or local agents/[/yellow]"
             )
             return
 
@@ -936,7 +937,7 @@ def main(
             console.print()
 
             # Setup prompt_toolkit with history
-            history_file = Path.home() / ".config" / "amcp" / "history.txt"
+            history_file = Path.home() / ".config" / CONFIG_DIR_NAME / "history.txt"
             history_file.parent.mkdir(parents=True, exist_ok=True)
             session: PromptSession[str] = PromptSession(history=FileHistory(str(history_file)))
 

--- a/src/ankaloop/commands.py
+++ b/src/ankaloop/commands.py
@@ -7,12 +7,12 @@ the `/command` syntax. They are defined as TOML files containing:
 - description: (optional) A brief description of the command
 
 Commands are discovered from:
-- User commands: ~/.config/amcp/commands/*.toml
-- Project commands: .amcp/commands/*.toml (takes precedence)
+- User commands: ~/.config/ankaloop/commands/*.toml
+- Project commands: .ankaloop/commands/*.toml (takes precedence)
 
 Naming convention:
 - Subdirectories create namespaced commands separated by ':'
-- Example: .amcp/commands/git/commit.toml -> /git:commit
+- Example: .ankaloop/commands/git/commit.toml -> /git:commit
 """
 
 from __future__ import annotations
@@ -35,7 +35,9 @@ if TYPE_CHECKING:
     pass
 
 # Default config directory
-CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp"
+from .constants import CONFIG_DIR_NAME, PROJECT_DIR_NAME
+
+CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME
 
 # Placeholder patterns
 ARGS_PLACEHOLDER = re.compile(r"\{\{args\}\}")
@@ -114,7 +116,7 @@ class CommandManager:
     def get_project_commands_dir(project_root: Path | None = None) -> Path:
         """Get the project-level commands directory."""
         root = project_root or Path.cwd()
-        return root / ".amcp" / "commands"
+        return root / PROJECT_DIR_NAME / "commands"
 
     def register_builtin(self, command: SlashCommand) -> None:
         """Register a built-in command."""

--- a/src/ankaloop/config.py
+++ b/src/ankaloop/config.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 import tomli_w  # type: ignore
 
+from .constants import CONFIG_DIR_NAME
 from .telegram.config import (
     TelegramConfig,
     TelegramGroupConfig,
@@ -28,7 +29,7 @@ from .telegram.config import (
     parse_user_ids,
 )
 
-CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp"
+CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
 

--- a/src/ankaloop/constants.py
+++ b/src/ankaloop/constants.py
@@ -1,0 +1,16 @@
+"""Shared filesystem layout constants.
+
+Single source of truth for on-disk directory names so the whole codebase
+moves together when the layout changes (e.g. the amcp -> ankaloop rename).
+
+ANKA_CONFIG_DIR_NAME overrides the config directory name (default
+"ankaloop"). Set it to the legacy value ("amcp") to keep old deployments
+working.
+"""
+
+from __future__ import annotations
+
+import os
+
+CONFIG_DIR_NAME = os.environ.get("ANKA_CONFIG_DIR_NAME", "ankaloop")
+PROJECT_DIR_NAME = ".ankaloop"

--- a/src/ankaloop/event_bus.py
+++ b/src/ankaloop/event_bus.py
@@ -48,6 +48,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
+from .constants import CONFIG_DIR_NAME
+
 logger = logging.getLogger(__name__)
 
 
@@ -653,7 +655,7 @@ async def emit_task_event(
             from .session_store import SessionTimelineStore
 
             SessionTimelineStore(
-                Path.home() / ".config" / "amcp" / "sessions",
+                Path.home() / ".config" / CONFIG_DIR_NAME / "sessions",
                 session_id,
             ).append(event_type.value, event.data, timestamp=event.timestamp.isoformat())
         except Exception as exc:

--- a/src/ankaloop/hooks.py
+++ b/src/ankaloop/hooks.py
@@ -6,8 +6,8 @@ allowing users to extend and customize agent behavior through external commands
 or Python scripts.
 
 Configuration:
-- Project-level: .amcp/hooks.toml
-- User-level: ~/.config/amcp/hooks.toml
+- Project-level: .ankaloop/hooks.toml
+- User-level: ~/.config/ankaloop/hooks.toml
 
 Hook Events:
 - PreToolUse: Before tool execution (can modify input or deny execution)
@@ -45,6 +45,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
+
+from .constants import CONFIG_DIR_NAME, PROJECT_DIR_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -360,7 +362,7 @@ class HooksManager:
             return
 
         # Load user-level config
-        user_config_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp"
+        user_config_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME
         user_hooks_file = user_config_dir / "hooks.toml"
         if user_hooks_file.exists():
             self._load_config_file(user_hooks_file)
@@ -371,17 +373,17 @@ class HooksManager:
             self._load_markdown_hooks_dir(user_hooks_dir)
 
         # Load project-level config (overrides user config)
-        project_hooks_file = self.project_dir / ".amcp" / "hooks.toml"
+        project_hooks_file = self.project_dir / PROJECT_DIR_NAME / "hooks.toml"
         if project_hooks_file.exists():
             self._load_config_file(project_hooks_file)
 
         # Also check for hooks.json for flexibility
-        project_hooks_json = self.project_dir / ".amcp" / "hooks.json"
+        project_hooks_json = self.project_dir / PROJECT_DIR_NAME / "hooks.json"
         if project_hooks_json.exists():
             self._load_json_config_file(project_hooks_json)
 
         # Load project-level markdown hooks
-        project_hooks_dir = self.project_dir / ".amcp" / "hooks"
+        project_hooks_dir = self.project_dir / PROJECT_DIR_NAME / "hooks"
         if project_hooks_dir.exists():
             self._load_markdown_hooks_dir(project_hooks_dir)
 
@@ -556,8 +558,8 @@ class HooksManager:
     def _load_plugin_hooks(self) -> None:
         """Load hooks from plugin directories."""
         plugin_dirs = [
-            self.project_dir / ".amcp" / "plugins",
-            Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp" / "plugins",
+            self.project_dir / PROJECT_DIR_NAME / "plugins",
+            Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME / "plugins",
         ]
 
         for plugin_base in plugin_dirs:

--- a/src/ankaloop/memory.py
+++ b/src/ankaloop/memory.py
@@ -6,8 +6,8 @@ Provides persistent cross-session memory for the agent using a two-layer approac
 - HISTORY.md: Append-only searchable log of past activities and learnings
 
 Memory is stored at:
-- User-level: ~/.config/amcp/memory/
-- Project-level: .amcp/memory/ (project-specific knowledge)
+- User-level: ~/.config/ankaloop/memory/
+- Project-level: .ankaloop/memory/ (project-specific knowledge)
 
 This enables the agent to remember important context across sessions,
 supporting self-evolution by accumulating knowledge over time.
@@ -22,10 +22,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+from .constants import CONFIG_DIR_NAME, PROJECT_DIR_NAME
+
 logger = logging.getLogger(__name__)
 
-# Default config directory
-CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp"
+
+CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME
 
 DEFAULT_SOUL = """You are AnkaLoop, a long-running autonomous coding agent.
 
@@ -118,7 +120,7 @@ class MemoryStore:
     def get_project_memory_dir(project_root: Path | None = None) -> Path:
         """Get project-level memory directory."""
         root = project_root or Path.cwd()
-        return root / ".amcp" / "memory"
+        return root / PROJECT_DIR_NAME / "memory"
 
     def _ensure_dir(self) -> None:
         """Ensure memory directory exists."""

--- a/src/ankaloop/models_db.py
+++ b/src/ankaloop/models_db.py
@@ -11,10 +11,12 @@ from typing import Any
 
 import httpx
 
+from .constants import CONFIG_DIR_NAME
+
 logger = logging.getLogger(__name__)
 
 # Default cache directory
-CACHE_DIR = Path.home() / ".config" / "amcp" / "cache"
+CACHE_DIR = Path.home() / ".config" / CONFIG_DIR_NAME / "cache"
 MODELS_CACHE_FILE = CACHE_DIR / "models.json"
 MODELS_DEV_API_URL = "https://models.dev/api.json"
 

--- a/src/ankaloop/skills.py
+++ b/src/ankaloop/skills.py
@@ -10,9 +10,9 @@ markdown files with YAML frontmatter containing:
 
 Skills are discovered from (in order of increasing precedence):
 - Built-in skills: Bundled with AnkaLoop (e.g., skill-creator)
-- User skills: ~/.config/amcp/skills/<skill-name>/SKILL.md
+- User skills: ~/.config/ankaloop/skills/<skill-name>/SKILL.md
 - Home agent skills: ~/.agents/skills/<skill-name>/SKILL.md
-- Project skills: .amcp/skills/<skill-name>/SKILL.md (highest precedence)
+- Project skills: .ankaloop/skills/<skill-name>/SKILL.md (highest precedence)
 """
 
 from __future__ import annotations
@@ -25,6 +25,8 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from .constants import CONFIG_DIR_NAME, PROJECT_DIR_NAME
 
 try:
     import yaml
@@ -39,8 +41,8 @@ logger = logging.getLogger(__name__)
 # Regex to parse YAML frontmatter
 FRONTMATTER_REGEX = re.compile(r"^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)", re.MULTILINE)
 
-# Default config directory
-CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "amcp"
+
+CONFIG_DIR = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / CONFIG_DIR_NAME
 
 
 @dataclass
@@ -94,7 +96,7 @@ class SkillManager:
 
     Skills are discovered from three sources (lowest to highest precedence):
     - Built-in skills: Bundled with AnkaLoop
-    - User-level skills: ~/.config/amcp/skills/
+    - User-level skills: ~/.config/ankaloop/skills/
     - Home agent skills: ~/.agents/skills/
     - Project-level skills: .amcp/skills/
     """
@@ -112,7 +114,7 @@ class SkillManager:
     def get_project_skills_dir(project_root: Path | None = None) -> Path:
         """Get the project-level skills directory."""
         root = project_root or Path.cwd()
-        return root / ".amcp" / "skills"
+        return root / PROJECT_DIR_NAME / "skills"
 
     @staticmethod
     def get_agents_skills_dir(project_root: Path | None = None) -> Path:
@@ -136,9 +138,9 @@ class SkillManager:
 
         Discovery order (lowest to highest precedence):
         1. Built-in skills (bundled with AnkaLoop)
-        2. User skills (~/.config/amcp/skills/)
+        2. User skills (~/.config/ankaloop/skills/)
         3. Home agent skills (~/.agents/skills/)
-        4. Project skills (.amcp/skills/) — highest precedence
+        4. Project skills (.ankaloop/skills/) — highest precedence
 
         Args:
             project_root: The project root directory (defaults to cwd)

--- a/src/ankaloop/telegram/bot.py
+++ b/src/ankaloop/telegram/bot.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 from ..agent import Agent, BusyError, create_agent_by_name
 from ..agent_spec import get_default_agent_spec
 from ..config import load_config, save_config
+from ..constants import CONFIG_DIR_NAME
 from ..event_bus import EventType, get_event_bus
 from ..memory import CONFIG_DIR
 from ..memory_dream import MemoryDreamer
@@ -807,7 +808,7 @@ class TelegramBot:
         await self._send_notification_inner(text)
 
     def tail_logs(self, lines: int) -> str:
-        log_path = Path.home() / ".config" / "amcp" / "logs" / "amcp.log"
+        log_path = Path.home() / ".config" / CONFIG_DIR_NAME / "logs" / "ankaloop.log"
         if not log_path.exists():
             return "No log file found."
         content = log_path.read_text(encoding="utf-8").splitlines()

--- a/src/ankaloop/tools.py
+++ b/src/ankaloop/tools.py
@@ -1407,8 +1407,8 @@ Actions:
 - delete_fact: Delete a fact by key
 
 Scopes:
-- user: Global memory (~/.config/amcp/memory/)
-- project: Project-specific memory (.amcp/memory/)
+- user: Global memory (~/.config/ankaloop/memory/)
+- project: Project-specific memory (.ankaloop/memory/)
 
 Identity and soul are global-only for prompt injection. Use scope="user" for
 identify, write_identity, and write_soul; project scope is for project facts and

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,7 +99,7 @@ class TestAgentInit:
         assert pinned.chat.base_url == "https://pinned.example/v1"
 
     def test_loads_existing_history(self, tmp_path):
-        sessions_dir = tmp_path / ".config" / "amcp" / "sessions"
+        sessions_dir = tmp_path / ".config" / "ankaloop" / "sessions"
         sessions_dir.mkdir(parents=True, exist_ok=True)
         session_file = sessions_dir / "test-session.json"
         state = SessionState(session_id="test-session", agent_name="default")
@@ -123,7 +123,7 @@ class TestAgentInit:
                 assert agent.total_llm_calls == 1
 
     def test_load_history_handles_corrupted_file(self, tmp_path):
-        session_file = tmp_path / ".config" / "amcp" / "sessions" / "test-session.json"
+        session_file = tmp_path / ".config" / "ankaloop" / "sessions" / "test-session.json"
         session_file.parent.mkdir(parents=True)
         session_file.write_text("not json")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,8 +2,26 @@ import ankaloop.config as config_module
 
 
 def test_config_dir_default():
-    assert config_module.CONFIG_DIR.name == "amcp"
+    assert config_module.CONFIG_DIR.name == "ankaloop"
     assert "config" in str(config_module.CONFIG_DIR).lower()
+
+
+def test_config_dir_name_override(monkeypatch, tmp_path):
+    """Legacy deployments can keep the old config dir via ANKA_CONFIG_DIR_NAME."""
+    import importlib
+
+    import ankaloop.config as cfg_mod
+    import ankaloop.constants as constants_mod
+
+    monkeypatch.setenv("ANKA_CONFIG_DIR_NAME", "amcp")
+    importlib.reload(constants_mod)
+    importlib.reload(cfg_mod)
+    assert cfg_mod.CONFIG_DIR.name == "amcp"
+
+    monkeypatch.setenv("ANKA_CONFIG_DIR_NAME", "ankaloop")
+    importlib.reload(constants_mod)
+    importlib.reload(cfg_mod)
+    assert cfg_mod.CONFIG_DIR.name == "ankaloop"
 
 
 def test_load_config():
@@ -187,7 +205,7 @@ def test_decode_encode_server_config_roundtrip():
         },
         "session_timeout_minutes": 30,
         "max_sessions": 10,
-        "work_dir": "/tmp/amcp",
+        "work_dir": "/tmp/ankaloop",
         "default_agent": "coder",
     }
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -45,7 +45,7 @@ def test_example_hook_toml_configs_load(tmp_path: Path) -> None:
 
     for hook_file in hook_files:
         project = tmp_path / hook_file.stem
-        hooks_dir = project / ".amcp"
+        hooks_dir = project / ".ankaloop"
         hooks_dir.mkdir(parents=True)
         (hooks_dir / "hooks.toml").write_text(hook_file.read_text(), encoding="utf-8")
 
@@ -57,7 +57,7 @@ def test_example_hook_toml_configs_load(tmp_path: Path) -> None:
 
 def test_example_command_toml_configs_load(tmp_path: Path) -> None:
     """Every example TOML command should load through CommandManager."""
-    commands_dir = tmp_path / ".amcp" / "commands"
+    commands_dir = tmp_path / ".ankaloop" / "commands"
     commands_dir.mkdir(parents=True)
     for command_file in (EXAMPLES / "commands").rglob("*.toml"):
         destination = commands_dir / command_file.relative_to(EXAMPLES / "commands")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -175,7 +175,7 @@ class TestHooksManager:
         """Test loading hooks from TOML config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             # Create hooks.toml
@@ -202,7 +202,7 @@ enabled = true
         """Test loading hooks from JSON config."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             # Create hooks.json
@@ -233,7 +233,7 @@ enabled = true
         """Test that disabled handlers are not returned."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             hooks_config = """
@@ -264,7 +264,7 @@ class TestHookExecution:
         """Test executing a command hook that succeeds."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             # Use JSON config for complex commands with embedded JSON output
@@ -300,7 +300,7 @@ class TestHookExecution:
         """Test executing a hook that denies tool execution."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             # Create a hook that denies writes
@@ -365,7 +365,7 @@ enabled = true
         """Test UserPromptSubmit hooks."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             # Use JSON config for complex commands with embedded JSON output
@@ -406,7 +406,7 @@ class TestEnvironmentVariables:
         """Test $ANKA_PROJECT_DIR substitution in commands."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_dir = Path(tmpdir)
-            amcp_dir = project_dir / ".amcp"
+            amcp_dir = project_dir / ".ankaloop"
             amcp_dir.mkdir()
 
             hooks_config = """

--- a/tests/test_skill_creator.py
+++ b/tests/test_skill_creator.py
@@ -117,7 +117,7 @@ class TestPrecedenceOrder:
         sm = SkillManager()
 
         # Create project-level skill
-        project_skill_dir = tmp_path / ".amcp" / "skills" / "skill-creator"
+        project_skill_dir = tmp_path / ".ankaloop" / "skills" / "skill-creator"
         project_skill_dir.mkdir(parents=True)
         (project_skill_dir / "SKILL.md").write_text(
             "---\nname: skill-creator\ndescription: Project override\n---\n\nProject body."

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -299,7 +299,7 @@ Agent skill body""")
         assert skill.description == "Skill from agents dir"
 
     def test_skills_precedence(self, skill_manager: SkillManager, temp_skills_dir: Path, monkeypatch):
-        """Test precedence: .amcp > ~/.agents > user"""
+        """Test precedence: .ankaloop > user"""
 
         # Setup user skills dir
         user_config_dir = temp_skills_dir / "user_config"
@@ -311,8 +311,8 @@ Agent skill body""")
         monkeypatch.setattr(Path, "home", lambda: home_dir)
         agents_skills_dir = home_dir / ".agents" / "skills"
 
-        # Setup .amcp/skills dir
-        project_skills_dir = temp_skills_dir / ".amcp" / "skills"
+        # Setup .ankaloop/skills dir
+        project_skills_dir = temp_skills_dir / ".ankaloop" / "skills"
 
         # Create directories
         for d in [user_skills_dir, agents_skills_dir, project_skills_dir]:


### PR DESCRIPTION
## Summary

Complete the AMCP→AnkaLoop rename for **on-disk paths**:

- User config dir: `~/.config/amcp` → `~/.config/ankaloop`
- Project dir: `.amcp/` → `.ankaloop/`
- Telegram log file: `amcp.log` → `ankaloop.log`

## Design

New single source of truth `src/ankaloop/constants.py`:

```python
CONFIG_DIR_NAME = os.environ.get("ANKA_CONFIG_DIR_NAME", "ankaloop")
PROJECT_DIR_NAME = ".ankaloop"
```

`ANKA_CONFIG_DIR_NAME=amcp` keeps legacy deployments on the old path, so existing installs can migrate at their own pace (documented in README).

Previously the literal `"amcp"` was duplicated in 10 modules (`config`, `commands`, `memory`, `skills`, `hooks`, `agent`, `event_bus`, `models_db`, `cli`, `telegram/bot`) and `.amcp` in 4 more — this PR centralizes all of them.

## Changes

- **src**: all path construction now imports from `constants`; docstrings updated
- **tests**: expectations aligned (`test_config` asserts `CONFIG_DIR.name == "ankaloop"`; new `test_config_dir_name_override` covers the legacy env var)
- **examples**: hooks/commands/plugins configs and workflow docs use `.ankaloop/`
- **deploy-gmi/Dockerfile**: creates `/workspace/.config/ankaloop`
- **.gitignore**: `.ankaloop/` added (legacy `.amcp/` pattern retained)
- **README**: documents the new layout + the legacy escape hatch

## Testing

- Full suite in a clean container: **966 passed, 0 failed** (`pytest -m "not llm"`)
- `ruff check` + `ruff format --check`: clean
- mypy on touched modules: clean (remaining warnings are pre-existing `telegramify_markdown` stub noise)

## Migration notes

Deployments that cannot rename dirs yet: set `ANKA_CONFIG_DIR_NAME=amcp` in the service environment.