### PR TITLE
fix(telegram): keep /skills listing compact and chunk oversized command output

### DIFF
--- a/src/ankaloop/commands.py
+++ b/src/ankaloop/commands.py
@@ -567,12 +567,7 @@ def _make_skills_command(skill_manager) -> SlashCommand:
                 status = "🔴 (disabled)" if skill.disabled else "🟢"
                 active = " ⭐" if sm.is_skill_active(skill.name) else ""
                 auto_trigger = " 🤖" if skill.auto_trigger else " 🚫"
-                lines.append(f"- {status} **{skill.name}**{active}{auto_trigger}: {skill.description}")
-                if skill.parameters:
-                    for param in skill.parameters:
-                        req = " (required)" if param.required else ""
-                        default = f" [default: {param.default}]" if param.default else ""
-                        lines.append(f"    - param `{param.name}`{req}{default}: {param.description}")
+                lines.append(f"- {status} **{skill.name}**{active}{auto_trigger}")
 
             lines.append("\nLegend: ⭐ = active, 🤖 = auto-trigger, 🚫 = explicit-only")
             return CommandResult(type="message", content="\n".join(lines))

--- a/src/ankaloop/telegram/bot.py
+++ b/src/ankaloop/telegram/bot.py
@@ -170,6 +170,38 @@ class _StreamingDeliveryManager:
             await self._bot.send_markdown(self._chat_id, chunk)
 
 
+def _utf16_len(text: str) -> int:
+    """Length of text in UTF-16 code units (Telegram's message limit unit)."""
+    return len(text) + sum(1 for ch in text if ord(ch) > 0xFFFF)
+
+
+def _split_plain_text(text: str, max_length: int) -> list[str]:
+    """Split plain text into chunks within a UTF-16 length limit, preferring newlines."""
+    if _utf16_len(text) <= max_length:
+        return [text]
+    parts: list[str] = []
+    remaining = text
+    limit = max(1, max_length)
+    while remaining:
+        # Longest prefix of remaining that fits in `limit` UTF-16 units.
+        units = 0
+        cut = 0
+        for i, ch in enumerate(remaining):
+            units += 2 if ord(ch) > 0xFFFF else 1
+            if units > limit:
+                break
+            cut = i + 1
+        if cut < len(remaining):
+            newline = remaining.rfind("\n", 0, cut)
+            if newline > 0:
+                cut = newline
+        parts.append(remaining[:cut].rstrip("\n"))
+        remaining = remaining[cut:].lstrip("\n")
+        if not parts[-1]:
+            break
+    return parts
+
+
 class TelegramBot:
     """Telegram bot that connects chat messages to an AnkaLoop agent."""
 
@@ -767,7 +799,16 @@ class TelegramBot:
         return int(message_id) if message_id is not None else None
 
     async def send_text(self, chat_id: int, text: str, *, reply_markup: Any = None) -> Any:
-        kwargs: dict[str, Any] = {"chat_id": chat_id, "text": text}
+        if _utf16_len(text) > self._formatter.max_length:
+            last_message: Any = None
+            text_parts = _split_plain_text(text, self._formatter.max_length)
+            for part in text_parts:
+                kwargs: dict[str, Any] = {"chat_id": chat_id, "text": part}
+                if reply_markup is not None and part is text_parts[-1]:
+                    kwargs["reply_markup"] = reply_markup
+                last_message = await self._application.bot.send_message(**kwargs)
+            return last_message
+        kwargs = {"chat_id": chat_id, "text": text}
         if reply_markup is not None:
             kwargs["reply_markup"] = reply_markup
         return await self._application.bot.send_message(**kwargs)

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -173,6 +173,33 @@ def test_formatter_uses_utf16_length_for_emoji():
     assert chunks == ["😀😀😀", "😀😀😀", "😀😀😀", "😀"]
 
 
+def test_split_plain_text_splits_on_utf16_limit():
+    from ankaloop.telegram.bot import _split_plain_text
+
+    # Each emoji is 2 UTF-16 units; limit 6 units = 3 emoji per chunk.
+    assert _split_plain_text("a" * 3, 10) == ["aaa"]
+    chunks = _split_plain_text("😀" * 7, 6)
+    assert chunks == ["😀😀😀", "😀😀😀", "😀"]
+    # Prefer splitting on newlines.
+    text = "\n".join(["line" + str(i) for i in range(200)])
+    parts = _split_plain_text(text, 100)
+    assert all(len(p) <= 100 for p in parts)
+    assert "\n".join(parts) == text or "\n".join(parts).replace("\n\n", "\n") == text
+
+
+def test_send_text_chunks_oversized_command_output(capsys):
+    from ankaloop.telegram.bot import _split_plain_text, _utf16_len
+
+    assert _utf16_len("abc") == 3
+    assert _utf16_len("😀") == 2
+    long_output = "skill-🔴😀\n" * 800
+    parts = _split_plain_text(long_output, 4096)
+    assert all(_utf16_len(p) <= 4096 for p in parts)
+    # Content preserved across chunks (modulo stripped blank lines).
+    rejoined = "".join(p + "\n" for p in parts).replace("\n\n", "\n")
+    assert rejoined.startswith("skill-🔴😀\n")
+
+
 def test_session_manager_creates_sessions():
     async def _run():
         manager = SessionManager(agent_factory=_FakeAgent, session_timeout=60)


### PR DESCRIPTION
## Problem
`/skills list` rendered every skill's description plus full parameter details. With 14+ discovered skills the output exceeded Telegram's 4096-char message limit, and the plain-text command path had no chunking, so `send_text` raised `telegram.error.BadRequest: Message is too long` — the command silently failed with no reply to the user.

## Changes
- `commands.py`: `/skills list` shows only skill names + status markers; descriptions/parameters stay available via `/skills show <name>`
- `telegram/bot.py`: `send_text` splits oversized plain-text messages at newline boundaries using UTF-16 code units (Telegram's actual limit unit); `reply_markup` attaches to the last chunk

## Verification
- New unit tests in `tests/test_telegram.py` (UTF-16 length + split behavior)
- Full pytest suite green in ephemeral container
- E2E in test container: worst-case 25-skill listing = 1116 UTF-16 units (well under 4096); synthetic 21.9K-unit payload chunks into 6 parts, all within limit

## Process note
This change was briefly direct-pushed to main by mistake and reverted in cf06bfa; this PR re-lands it through proper review.