### PR TITLE
docs: update stale skill directory paths to current layout

### DIFF
--- a/src/ankaloop/builtin_skills/session-cleanup/SKILL.md
+++ b/src/ankaloop/builtin_skills/session-cleanup/SKILL.md
@@ -14,15 +14,15 @@ Backup old AnkaLoop sessions by renaming with execution date, then clean and com
 
 ## What to Clean
 
-1. **Session files backup**: Rename session JSON files in `~/.config/amcp/sessions/` that haven't been modified in 30+ days to `YYYY-MM-DD_<original_name>.json.bak`
+1. **Session files backup**: Rename session JSON files in `~/.config/ankaloop/sessions/` that haven't been modified in 30+ days to `YYYY-MM-DD_<original_name>.json.bak`
 2. **Active sessions keep**: Keep the most recent 10 session files (by modification time) as active
-3. **Memory compaction**: Compact `~/.config/amcp/memory/HISTORY.md` to keep only the last 50 entries
+3. **Memory compaction**: Compact `~/.config/ankaloop/memory/HISTORY.md` to keep only the last 50 entries
 
 ## Procedure
 
 ### Step 1: Backup Old Sessions
 
-1. List all `.json` files in `~/.config/amcp/sessions/` directory
+1. List all `.json` files in `~/.config/ankaloop/sessions/` directory
 2. Get modification time of each file
 3. Sort by modification time (oldest first)
 4. Keep the 10 most recent files as active
@@ -37,7 +37,7 @@ Backup old AnkaLoop sessions by renaming with execution date, then clean and com
 
 ### Step 3: Compact Memory
 
-1. Read `~/.config/amcp/memory/HISTORY.md`
+1. Read `~/.config/ankaloop/memory/HISTORY.md`
 2. Count the number of entries (each `-` bullet is an entry)
 3. If more than 50 entries, keep only the last 50 entries
 4. Add a summary entry at the top: "Compacted from X entries to 50 entries on YYYY-MM-DD"

--- a/src/ankaloop/builtin_skills/skill-creator/SKILL.md
+++ b/src/ankaloop/builtin_skills/skill-creator/SKILL.md
@@ -18,9 +18,9 @@ equipped with procedural knowledge that no model can fully possess.
 
 When creating a skill, place it in one of these roots:
 
-1. Project-local: `$workspace/.amcp/skills/<skill-name>`
+1. Project-local: `$workspace/.ankaloop/skills/<skill-name>`
 2. Home agent-level: `~/.agents/skills/<skill-name>` (shared across agent tools)
-3. User-level: `~/.config/amcp/skills/<skill-name>` (shared across AnkaLoop workspaces)
+3. User-level: `~/.config/ankaloop/skills/<skill-name>` (shared across AnkaLoop workspaces)
 
 Prefer project-local by default. Use home agent-level or user-level only when the user explicitly wants the skill available across multiple workspaces.
 
@@ -169,16 +169,16 @@ Examples:
 
 ```bash
 # Project-local skill
-python <path>/scripts/init_skill.py my-skill --path .amcp/skills
+python <path>/scripts/init_skill.py my-skill --path .ankaloop/skills
 
 # User-level skill
-python <path>/scripts/init_skill.py my-skill --path ~/.config/amcp/skills
+python <path>/scripts/init_skill.py my-skill --path ~/.config/ankaloop/skills
 
 # Home agent-level skill
 python <path>/scripts/init_skill.py my-skill --path ~/.agents/skills
 
 # With specific resources
-python <path>/scripts/init_skill.py my-skill --path .amcp/skills --resources scripts,references
+python <path>/scripts/init_skill.py my-skill --path .ankaloop/skills --resources scripts,references
 ```
 
 The script creates the skill directory with a SKILL.md template and optional resource directories.

--- a/src/ankaloop/skills.py
+++ b/src/ankaloop/skills.py
@@ -98,7 +98,7 @@ class SkillManager:
     - Built-in skills: Bundled with AnkaLoop
     - User-level skills: ~/.config/ankaloop/skills/
     - Home agent skills: ~/.agents/skills/
-    - Project-level skills: .amcp/skills/
+    - Project-level skills: .ankaloop/skills/
     """
 
     _skills: list[SkillMetadata] = field(default_factory=list)


### PR DESCRIPTION
## Summary

The  rebrand (PR #39) updated  (,  default ) and all functional code paths, but three documentation surfaces were missed:

- **skill-creator/SKILL.md** (5 refs): skill placement examples and  CLI commands still used  and 
- **session-cleanup/SKILL.md** (4 refs): session/memory paths still used  and 
- **skills.py SkillManager docstring** (1 ref): project-level skills comment still said 

No functional changes — all code paths already use the  /  constants. This PR aligns the documentation so copy-pasted commands create files in the right directories.

## Verification

- `ruff check` + `ruff format --check`: pass
- `pytest tests/ -q -m "not llm"` in clean container: 968 passed