### PR TITLE
fix(tools): bound MCP bridge thread join with a timeout

### DIFF
--- a/src/ankaloop/tools.py
+++ b/src/ankaloop/tools.py
@@ -213,8 +213,14 @@ def _validate_callable_arguments(name: str, func: Callable[..., Any], arguments:
         raise ToolValidationError(f"Tool '{name}' arguments do not match its signature: {exc}") from exc
 
 
-def _run_coroutine_in_thread(coro: Any) -> Any:
-    """Run a coroutine from synchronous tool code, even under an active event loop."""
+def _run_coroutine_in_thread(coro: Any, timeout: float | None = None) -> Any:
+    """Run a coroutine from synchronous tool code, even under an active event loop.
+
+    The coroutine runs in a daemon worker thread with its own event loop, so the
+    caller can never be blocked forever by a coroutine that never completes: when
+    ``timeout`` is given, ``worker.join(timeout)`` gives up waiting and raises
+    :class:`ToolExecutionError` instead of hanging the calling thread.
+    """
 
     result: dict[str, Any] = {}
     error: dict[str, BaseException] = {}
@@ -227,8 +233,12 @@ def _run_coroutine_in_thread(coro: Any) -> Any:
 
     worker = threading.Thread(target=_runner, daemon=True)
     worker.start()
-    worker.join()
+    worker.join(timeout)
 
+    if worker.is_alive():
+        raise ToolExecutionError(
+            f"MCP call timed out after {timeout:.1f} seconds; the worker thread was abandoned"
+        )
     if "value" in error:
         raise error["value"]
     return result.get("value")
@@ -305,12 +315,17 @@ def _call_firecrawl_mcp(tool_name: str, arguments: dict[str, Any]) -> dict[str, 
     """
     import json
 
-    from .mcp_client import call_mcp_tool
+    from .mcp_client import DEFAULT_MCP_TIMEOUT, call_mcp_tool
 
     server = _get_firecrawl_server_config()
+    # A little slack over the in-coroutine timeout so call_mcp_tool's own
+    # wait_for error wins when it can; the join timeout is only a backstop.
     response = cast(
         dict[str, Any],
-        _run_coroutine_in_thread(call_mcp_tool(server, tool_name, arguments)),
+        _run_coroutine_in_thread(
+            call_mcp_tool(server, tool_name, arguments),
+            timeout=DEFAULT_MCP_TIMEOUT + 10.0,
+        ),
     )
     if response.get("is_error"):
         text = _render_mcp_text_response("Web provider error", response)
@@ -371,10 +386,17 @@ def _get_exa_server_config():
 
 
 def _call_exa_tool(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    from .mcp_client import call_mcp_tool
+    from .mcp_client import DEFAULT_MCP_TIMEOUT, call_mcp_tool
 
     server = _get_exa_server_config()
-    return cast(dict[str, Any], _run_coroutine_in_thread(call_mcp_tool(server, tool_name, arguments)))
+    # Same slack as the firecrawl path: let call_mcp_tool's own timeout error win.
+    return cast(
+        dict[str, Any],
+        _run_coroutine_in_thread(
+            call_mcp_tool(server, tool_name, arguments),
+            timeout=DEFAULT_MCP_TIMEOUT + 10.0,
+        ),
+    )
 
 
 def _render_mcp_text_response(prefix: str, response: dict[str, Any]) -> str:

--- a/src/ankaloop/tools.py
+++ b/src/ankaloop/tools.py
@@ -236,9 +236,7 @@ def _run_coroutine_in_thread(coro: Any, timeout: float | None = None) -> Any:
     worker.join(timeout)
 
     if worker.is_alive():
-        raise ToolExecutionError(
-            f"MCP call timed out after {timeout:.1f} seconds; the worker thread was abandoned"
-        )
+        raise ToolExecutionError(f"MCP call timed out after {timeout:.1f} seconds; the worker thread was abandoned")
     if "value" in error:
         raise error["value"]
     return result.get("value")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,11 @@
+import asyncio
 import json
 import re
+import threading
+import time
 from unittest.mock import patch
+
+import pytest
 
 from ankaloop import tools as tools_module
 from ankaloop.config import AnkaloopConfig, ChatConfig
@@ -339,3 +344,40 @@ class TestTodoTool:
         assert "todo" in registry.list_tools()
         assert "web_search" in registry.list_tools()
         assert "web_fetch" in registry.list_tools()
+
+
+class TestRunCoroutineInThread:
+    """_run_coroutine_in_thread must never block the caller forever."""
+
+    def test_returns_result(self):
+        from ankaloop.tools import _run_coroutine_in_thread
+
+        async def coro():
+            return 42
+
+        assert _run_coroutine_in_thread(coro()) == 42
+
+    def test_propagates_exception(self):
+        from ankaloop.tools import _run_coroutine_in_thread
+
+        async def coro():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            _run_coroutine_in_thread(coro())
+
+    def test_join_timeout_raises_and_unblocks(self):
+        from ankaloop.tools import ToolExecutionError, _run_coroutine_in_thread
+
+        started = threading.Event()
+
+        async def hung():
+            started.set()
+            await asyncio.sleep(60)
+
+        begin = time.monotonic()
+        with pytest.raises(ToolExecutionError, match="timed out"):
+            _run_coroutine_in_thread(hung(), timeout=0.2)
+        elapsed = time.monotonic() - begin
+        assert elapsed < 5, "join timeout should unblock the caller quickly"
+        assert started.is_set(), "worker coroutine should have started before timing out"


### PR DESCRIPTION
## Summary

`_run_coroutine_in_thread` runs MCP coroutines in a daemon worker thread with its own event loop, but `worker.join()` had no timeout — if the coroutine never completed (e.g. an unresponsive MCP server), the calling thread blocked forever.

- Add an optional `timeout` to `_run_coroutine_in_thread`: `worker.join(timeout)` + `worker.is_alive()` check raises `ToolExecutionError` instead of hanging
- Wire both MCP call sites (`_call_firecrawl_mcp`, `_call_exa_tool`) with `DEFAULT_MCP_TIMEOUT + 10s` slack, so `call_mcp_tool`'s own `wait_for` timeout error wins when it can; the join timeout is only a backstop

## Testing

- 3 new tests in `TestRunCoroutineInThread`: normal return, exception propagation, hung-coroutine timeout raises and unblocks in <5s
- Full suite in a clean container: 971 passed