### PR TITLE
refactor: unify application session lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           pip install -e ".[dev,telegram]"
 
       - name: Run tests with pytest
-        run: pytest --cov --cov-report=xml -v -m "not llm"
+        run: pytest --cov-report=xml -m "not llm"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Unified application session lifecycle**: prompts across CLI, server, embedded client,
+  Telegram, and delegated tasks now share canonical turn events, results, error envelopes,
+  metrics, and queue ownership; the legacy message queue manager is deprecated.
+
 ### Fixed
 
+- **Runtime and persistence reliability**: observer failures no longer strand turns, synchronous
+  tool cancellation has a bounded settle deadline, failed memory consolidation remains retryable
+  without advancing its cursor, and session deletion shares the save lock.
+- **Configuration and authorization enforcement**: `edit_tool_enabled`, parent-scoped sub-agents,
+  explicit hook fail-open/fail-closed behavior, and the complete Telegram client contract are now
+  enforced.
 - **Skill directory paths in docs**: stale pre-rename `.amcp` paths in the skill-creator and session-cleanup SKILL.md examples and a `SkillManager` docstring aligned with the current `.ankaloop` layout (`#41`).
 
 ---

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ default_max_lines = 400
 mcp_tools_enabled = true
 write_tool_enabled = true
 edit_tool_enabled = true
+sync_tool_settle_timeout_seconds = 2.0
 default_agent = "coder"
 
 [context]

--- a/docs/design/phase2-agent-capabilities.md
+++ b/docs/design/phase2-agent-capabilities.md
@@ -90,6 +90,10 @@ registry.register(custom)
 
 ## 2. Message Queue System (`message_queue.py`)
 
+> **Deprecated:** Production request scheduling is now owned by `SessionRuntime`
+> through `ApplicationSessionService`. The APIs below remain only as a compatibility
+> reference and should not be used by new integrations.
+
 ### Core Concepts
 
 - **Session-specific queues**: Each session has its own message queue

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -40,6 +40,7 @@ matcher = "write_file|apply_patch"  # Regex pattern to match tool names
 type = "command"                  # "command" or "python"
 command = "./scripts/validate-writes.sh"
 timeout = 30                      # Timeout in seconds
+failure_mode = "closed"           # "open" (default) or "closed"
 enabled = true
 
 [[hooks.PreToolUse.handlers]]
@@ -55,6 +56,13 @@ type = "command"
 command = "$ANKA_PROJECT_DIR/scripts/lint-file.sh"
 timeout = 60
 ```
+
+`failure_mode` controls what happens when a hook cannot execute or times out:
+
+- `open` logs the failure and allows execution to continue.
+- `closed` denies the operation. Use this for policy and security enforcement hooks.
+
+This setting is independent from a hook's normal allow/deny result.
 
 ### JSON Format
 

--- a/examples/hooks/security-validation.toml
+++ b/examples/hooks/security-validation.toml
@@ -10,6 +10,7 @@ matcher = "write_file|apply_patch"
 type = "python"
 script = "./validate_file_writes.py"
 timeout = 30
+failure_mode = "closed"
 enabled = true
 
 [[hooks.PreToolUse.handlers]]
@@ -18,6 +19,7 @@ matcher = "write_file|apply_patch"
 type = "python"
 script = "./scripts/scan_secrets.py"
 timeout = 30
+failure_mode = "closed"
 enabled = true
 
 [[hooks.PreToolUse.handlers]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,6 @@ line-length = 100
 select = ["E", "F", "UP", "B", "SIM", "I"]
 ignore = ["E501"]
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = "-v --cov=src/ankaloop --cov-report=term-missing"
-
 [tool.mypy]
 python_version = "3.11"
 warn_return_any = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,6 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short
+addopts = -v --tb=short --cov=ankaloop --cov-branch --cov-report=term-missing
 markers =
     llm: tests that call live LLM provider APIs and require provider credentials

--- a/src/ankaloop/__init__.py
+++ b/src/ankaloop/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "MaxStepsReached",
     "BusyError",
     "ApplicationServices",
+    "ApplicationSessionService",
+    "SessionMetrics",
     "ContextBuilder",
     "ToolLoop",
     "TurnService",
@@ -28,6 +30,12 @@ __all__ = [
     "QueuedMessage",
     "MessageQueueManager",
     "get_message_queue_manager",
+    # Runtime contracts
+    "ErrorEnvelope",
+    "TurnEvent",
+    "TurnHandle",
+    "TurnResult",
+    "TurnStatus",
     # Event bus
     "Event",
     "EventBus",
@@ -110,6 +118,7 @@ from .agent import (
     list_subagent_types,
 )
 from .application_services import ApplicationServices
+from .application_session import ApplicationSessionService, SessionMetrics
 from .commands import (
     CommandManager,
     CommandResult,
@@ -157,12 +166,7 @@ from .hooks import (
     run_stop_hooks,
     run_user_prompt_hooks,
 )
-from .message_queue import (
-    MessagePriority,
-    MessageQueueManager,
-    QueuedMessage,
-    get_message_queue_manager,
-)
+from .message_queue import MessageQueueManager, QueuedMessage, get_message_queue_manager
 from .models_db import (
     ModelInfo,
     ModelsDatabase,
@@ -181,6 +185,14 @@ from .project_rules import (
     ProjectRulesLoader,
     get_project_rules_info,
     load_project_rules,
+)
+from .runtime import (
+    ErrorEnvelope,
+    MessagePriority,
+    TurnEvent,
+    TurnHandle,
+    TurnResult,
+    TurnStatus,
 )
 from .skills import (
     SkillManager,

--- a/src/ankaloop/agent.py
+++ b/src/ankaloop/agent.py
@@ -746,6 +746,27 @@ class Agent:
         reject_if_busy: bool = False,
     ) -> TurnHandle:
         """Submit a turn and return a handle that owns its eventual result."""
+        return await self.services.session_service.submit(
+            self,
+            user_input,
+            work_dir=work_dir,
+            stream=stream,
+            show_progress=show_progress,
+            priority=priority,
+            reject_if_busy=reject_if_busy,
+        )
+
+    async def _submit_turn(
+        self,
+        user_input: str,
+        *,
+        work_dir: Path | None = None,
+        stream: bool = True,
+        show_progress: bool = True,
+        priority: MessagePriority = MessagePriority.NORMAL,
+        reject_if_busy: bool = False,
+    ) -> TurnHandle:
+        """Submit directly to the owned runtime for the application session service."""
         async with self._lifecycle_lock:
             if self._closed:
                 raise RuntimeClosedError(f"Agent session {self.session_id} is closed")

--- a/src/ankaloop/agent.py
+++ b/src/ankaloop/agent.py
@@ -34,14 +34,20 @@ from .mcp_client import list_mcp_tools
 from .mcp_naming import is_mcp_tool_name, mcp_tool_name
 from .memory import get_memory_manager
 from .memory_review import run_memory_review
-from .message_queue import MessagePriority
 from .multi_agent import AgentConfig, get_agent_registry
 from .progressive.context_budget import ContextBudget, ContextBudgetManager, estimate_text_tokens
 from .progressive.relevance import RelevanceScorer
 from .progressive.skill_view import ProgressiveSkillView
 from .progressive.tool_view import ProgressiveToolView
 from .project_rules import ProjectRulesLoader
-from .runtime import CancellationResult, RuntimeClosedError, SessionRuntime, TurnCancelledError, TurnHandle, TurnRequest
+from .runtime import (
+    CancellationResult,
+    MessagePriority,
+    RuntimeClosedError,
+    SessionRuntime,
+    TurnHandle,
+    TurnRequest,
+)
 from .session_search import get_transcript_store  # noqa: F401 - legacy patch seam
 from .session_state import SessionState
 from .session_store import SessionStore, SessionTimelineStore
@@ -719,7 +725,8 @@ class Agent:
             MaxStepsReached: If max steps exceeded
             BusyError: If session is busy and queue_if_busy is False
         """
-        handle = await self.submit(
+        return await self.services.session_service.run(
+            self,
             user_input,
             work_dir=work_dir,
             stream=stream,
@@ -727,21 +734,6 @@ class Agent:
             priority=priority,
             reject_if_busy=not queue_if_busy,
         )
-        try:
-            return await handle.wait()
-        except TurnCancelledError:
-            raise
-        except asyncio.CancelledError as cancelled:
-            cancel_task = asyncio.create_task(handle.cancel())
-            while not cancel_task.done():
-                try:
-                    await asyncio.shield(cancel_task)
-                except asyncio.CancelledError:
-                    continue
-            if not cancel_task.cancelled():
-                with contextlib.suppress(Exception):
-                    cancel_task.result()
-            raise cancelled
 
     async def submit(
         self,
@@ -976,6 +968,10 @@ class Agent:
     def queued_count(self) -> int:
         """Get the number of queued messages for this session."""
         return self._runtime.queued_count
+
+    def has_pending_work(self, *, excluding: TurnHandle | None = None) -> bool:
+        """Return whether this session has other active or queued work."""
+        return self._runtime.has_pending_work(excluding=excluding)
 
     def queued_prompts(self) -> list[str]:
         """Get list of queued prompts for this session."""

--- a/src/ankaloop/application_services.py
+++ b/src/ankaloop/application_services.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+from .application_session import ApplicationSessionService
 from .memory import MemoryManager, get_memory_manager
 from .multi_agent import AgentRegistry, get_agent_registry
 from .session_search import TranscriptStore, get_transcript_store
@@ -71,6 +72,7 @@ class ApplicationServices:
     skill_manager: SkillManager
     transcript_store: TranscriptStoreService
     memory_manager_factory: Callable[[Path | None], MemoryManager]
+    session_service: ApplicationSessionService = field(default_factory=ApplicationSessionService)
 
     @classmethod
     def default(cls) -> ApplicationServices:
@@ -81,6 +83,7 @@ class ApplicationServices:
             skill_manager=get_skill_manager(),
             transcript_store=LegacyTranscriptStoreAdapter(get_transcript_store),
             memory_manager_factory=get_memory_manager,
+            session_service=ApplicationSessionService(),
         )
 
     def memory_manager(self, project_root: Path | None = None) -> MemoryManager:

--- a/src/ankaloop/application_session.py
+++ b/src/ankaloop/application_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import weakref
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -44,11 +45,11 @@ class ApplicationSessionService:
     """
 
     def __init__(self) -> None:
-        self._metrics: dict[str, SessionMetrics] = {}
+        self._metrics: weakref.WeakKeyDictionary[Agent, SessionMetrics] = weakref.WeakKeyDictionary()
 
     def metrics_for(self, agent: Agent) -> SessionMetrics:
         """Return the metrics projection for an agent session."""
-        metrics = self._metrics.get(agent.session_id)
+        metrics = self._metrics.get(agent)
         if metrics is None:
             metrics = SessionMetrics(
                 prompt_tokens=agent.total_input_tokens,
@@ -56,12 +57,12 @@ class ApplicationSessionService:
                 total_tokens=agent.total_input_tokens + agent.total_output_tokens,
                 updated_at=datetime.now(),
             )
-            self._metrics[agent.session_id] = metrics
+            self._metrics[agent] = metrics
         return metrics
 
-    def forget(self, session_id: str) -> None:
+    def forget(self, agent: Agent) -> None:
         """Drop application metrics after a session is permanently removed."""
-        self._metrics.pop(session_id, None)
+        self._metrics.pop(agent, None)
 
     async def submit(
         self,
@@ -77,7 +78,7 @@ class ApplicationSessionService:
     ) -> TurnHandle:
         """Submit one turn through the agent's single runtime owner."""
         resolved_priority = self._resolve_priority(priority)
-        handle = await agent.submit(
+        handle = await agent._submit_turn(
             content,
             work_dir=work_dir,
             stream=stream,

--- a/src/ankaloop/application_session.py
+++ b/src/ankaloop/application_session.py
@@ -1,0 +1,164 @@
+"""Transport-neutral application service for session turn submission."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .runtime import (
+    MessagePriority,
+    TurnCancelledError,
+    TurnEvent,
+    TurnHandle,
+    TurnStatus,
+)
+
+if TYPE_CHECKING:
+    from .agent import Agent
+
+TurnEventListener = Callable[[TurnEvent], None]
+
+
+@dataclass(slots=True)
+class SessionMetrics:
+    """Application-level metrics derived from completed runtime turns."""
+
+    status: str = "idle"
+    message_count: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    updated_at: datetime | None = None
+
+
+class ApplicationSessionService:
+    """Submit turns and project runtime lifecycle into session metrics.
+
+    CLI, embedded, server, Telegram, and delegated task entry points use this
+    service so transport code does not own execution counters or status changes.
+    """
+
+    def __init__(self) -> None:
+        self._metrics: dict[str, SessionMetrics] = {}
+
+    def metrics_for(self, agent: Agent) -> SessionMetrics:
+        """Return the metrics projection for an agent session."""
+        metrics = self._metrics.get(agent.session_id)
+        if metrics is None:
+            metrics = SessionMetrics(
+                prompt_tokens=agent.total_input_tokens,
+                completion_tokens=agent.total_output_tokens,
+                total_tokens=agent.total_input_tokens + agent.total_output_tokens,
+                updated_at=datetime.now(),
+            )
+            self._metrics[agent.session_id] = metrics
+        return metrics
+
+    def forget(self, session_id: str) -> None:
+        """Drop application metrics after a session is permanently removed."""
+        self._metrics.pop(session_id, None)
+
+    async def submit(
+        self,
+        agent: Agent,
+        content: str,
+        *,
+        work_dir: Path | None = None,
+        stream: bool = True,
+        show_progress: bool = False,
+        priority: MessagePriority | str = MessagePriority.NORMAL,
+        reject_if_busy: bool = False,
+        on_event: TurnEventListener | None = None,
+    ) -> TurnHandle:
+        """Submit one turn through the agent's single runtime owner."""
+        resolved_priority = self._resolve_priority(priority)
+        handle = await agent.submit(
+            content,
+            work_dir=work_dir,
+            stream=stream,
+            show_progress=show_progress,
+            priority=resolved_priority,
+            reject_if_busy=reject_if_busy,
+        )
+        metrics = self.metrics_for(agent)
+        metrics.status = "busy"
+        metrics.updated_at = datetime.now()
+        handle.add_done_callback(lambda completed: self._project_completion(agent, completed))
+        if on_event is not None:
+            with contextlib.suppress(Exception):
+                on_event(TurnEvent.transition(handle.id, TurnStatus.QUEUED))
+            handle.add_event_callback(on_event)
+        return handle
+
+    async def run(
+        self,
+        agent: Agent,
+        content: str,
+        *,
+        work_dir: Path | None = None,
+        stream: bool = True,
+        show_progress: bool = False,
+        priority: MessagePriority | str = MessagePriority.NORMAL,
+        reject_if_busy: bool = False,
+        on_event: TurnEventListener | None = None,
+    ) -> str:
+        """Submit and await one turn while preserving cancellation ownership."""
+        handle = await self.submit(
+            agent,
+            content,
+            work_dir=work_dir,
+            stream=stream,
+            show_progress=show_progress,
+            priority=priority,
+            reject_if_busy=reject_if_busy,
+            on_event=on_event,
+        )
+        try:
+            return await handle.wait()
+        except TurnCancelledError:
+            raise
+        except asyncio.CancelledError as cancelled:
+            cancel_task = asyncio.create_task(handle.cancel())
+            while not cancel_task.done():
+                try:
+                    await asyncio.shield(cancel_task)
+                except asyncio.CancelledError:
+                    continue
+            if not cancel_task.cancelled():
+                with contextlib.suppress(Exception):
+                    cancel_task.result()
+            raise cancelled
+
+    def _project_completion(self, agent: Agent, handle: TurnHandle) -> None:
+        """Update counters exactly once when a turn reaches a terminal state."""
+        metrics = self.metrics_for(agent)
+        has_pending_work = agent.has_pending_work(excluding=handle)
+        if handle.status == TurnStatus.COMPLETED:
+            metrics.message_count += 1
+            metrics.status = "busy" if has_pending_work else "idle"
+        elif handle.status == TurnStatus.CANCELLED:
+            metrics.status = "busy" if has_pending_work else "cancelled"
+        else:
+            metrics.status = "busy" if has_pending_work else "error"
+        metrics.prompt_tokens = agent.total_input_tokens
+        metrics.completion_tokens = agent.total_output_tokens
+        metrics.total_tokens = metrics.prompt_tokens + metrics.completion_tokens
+        metrics.updated_at = datetime.now()
+
+    @staticmethod
+    def _resolve_priority(priority: MessagePriority | str) -> MessagePriority:
+        """Normalize public priority strings into the runtime enum."""
+        if isinstance(priority, MessagePriority):
+            return priority
+        priorities = {
+            "low": MessagePriority.LOW,
+            "normal": MessagePriority.NORMAL,
+            "high": MessagePriority.HIGH,
+            "urgent": MessagePriority.URGENT,
+        }
+        return priorities.get(str(priority).lower(), MessagePriority.NORMAL)

--- a/src/ankaloop/cli.py
+++ b/src/ankaloop/cli.py
@@ -911,7 +911,13 @@ def main(
             # Single message mode
             console.print(f"[bold]🤖 Agent {agent.name}[/bold] - Processing...")
             response = asyncio.run(
-                agent.run(user_input=message, work_dir=work_dir, stream=False, show_progress=not no_progress)
+                agent.services.session_service.run(
+                    agent,
+                    message,
+                    work_dir=work_dir,
+                    stream=False,
+                    show_progress=not no_progress,
+                )
             )
 
             console.print(Panel(Markdown(response), title=f"Agent {agent.name}", border_style="cyan"))
@@ -1040,7 +1046,13 @@ def main(
 
                     console.print(f"[bold]🤖 Agent {agent.name}[/bold] - Processing...")
                     response = asyncio.run(
-                        agent.run(user_input=user_input, work_dir=work_dir, stream=False, show_progress=not no_progress)
+                        agent.services.session_service.run(
+                            agent,
+                            user_input,
+                            work_dir=work_dir,
+                            stream=False,
+                            show_progress=not no_progress,
+                        )
                     )
 
                     console.print(Panel(Markdown(response), title=f"Agent {agent.name}", border_style="cyan"))

--- a/src/ankaloop/client/embedded.py
+++ b/src/ankaloop/client/embedded.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+from ..application_services import ApplicationServices
 from .base import BaseClient, ResponseChunk
 from .exceptions import SessionError, SessionNotFoundError
 
@@ -24,6 +25,7 @@ class EmbeddedSession:
         agent: Any,  # Agent type
         cwd: str,
         agent_name: str,
+        services: ApplicationServices,
     ):
         """Initialize the embedded session.
 
@@ -38,20 +40,20 @@ class EmbeddedSession:
         self.cwd = cwd
         self.agent_name = agent_name
         self.created_at = datetime.now()
-        self.updated_at = datetime.now()
-        self.message_count = 0
+        self.services = services
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         status = self.agent.get_queue_status()["status"]
+        metrics = self.services.session_service.metrics_for(self.agent)
         return {
             "id": self.id,
             "cwd": self.cwd,
             "agent_name": self.agent_name,
             "created_at": self.created_at.isoformat(),
-            "updated_at": self.updated_at.isoformat(),
+            "updated_at": (metrics.updated_at or self.created_at).isoformat(),
             "status": status,
-            "message_count": self.message_count,
+            "message_count": metrics.message_count,
         }
 
 
@@ -68,8 +70,9 @@ class EmbeddedClient(BaseClient):
                 print(chunk.content)
     """
 
-    def __init__(self):
+    def __init__(self, services: ApplicationServices | None = None):
         """Initialize the embedded client."""
+        self.services = services or ApplicationServices.default()
         self._sessions: dict[str, EmbeddedSession] = {}
         self._closing_sessions: set[str] = set()
         self._connected = False
@@ -116,9 +119,8 @@ class EmbeddedClient(BaseClient):
             Info dictionary.
         """
         from .. import __version__
-        from ..multi_agent import get_agent_registry
 
-        registry = get_agent_registry()
+        registry = self.services.agent_registry
         return {
             "name": "ankaloop-embedded",
             "version": __version__,
@@ -150,7 +152,6 @@ class EmbeddedClient(BaseClient):
         """
         from ..agent import Agent, create_agent_by_name
         from ..agent_spec import get_default_agent_spec
-        from ..multi_agent import get_agent_registry
 
         # Generate session ID
         sid = session_id or str(uuid.uuid4())[:8]
@@ -162,9 +163,13 @@ class EmbeddedClient(BaseClient):
 
         # Create agent
         if agent_name:
-            registry = get_agent_registry()
+            registry = self.services.agent_registry
             if agent_name in registry.list_agents():
-                agent = create_agent_by_name(agent_name, session_id=sid)
+                agent = create_agent_by_name(
+                    agent_name,
+                    session_id=sid,
+                    services=self.services,
+                )
                 resolved_name = agent_name
             else:
                 # Try as agent spec file
@@ -174,16 +179,16 @@ class EmbeddedClient(BaseClient):
 
                 try:
                     spec = load_agent_spec(Path(agent_name))
-                    agent = Agent(spec, session_id=sid)
+                    agent = Agent(spec, session_id=sid, services=self.services)
                     resolved_name = spec.name
                 except Exception:
                     # Fall back to default
                     spec = get_default_agent_spec()
-                    agent = Agent(spec, session_id=sid)
+                    agent = Agent(spec, session_id=sid, services=self.services)
                     resolved_name = spec.name
         else:
             spec = get_default_agent_spec()
-            agent = Agent(spec, session_id=sid)
+            agent = Agent(spec, session_id=sid, services=self.services)
             resolved_name = spec.name
 
         # Create session
@@ -192,6 +197,7 @@ class EmbeddedClient(BaseClient):
             agent=agent,
             cwd=work_dir,
             agent_name=resolved_name,
+            services=self.services,
         )
         self._sessions[sid] = session
 
@@ -241,6 +247,7 @@ class EmbeddedClient(BaseClient):
         finally:
             self._sessions.pop(session_id, None)
             self._closing_sessions.discard(session_id)
+            self.services.session_service.forget(session_id)
 
     # =========================================================================
     # Prompt Operations
@@ -270,8 +277,6 @@ class EmbeddedClient(BaseClient):
             raise SessionNotFoundError(session_id)
 
         session = self._sessions[session_id]
-        session.updated_at = datetime.now()
-        session.message_count += 1
 
         if stream:
             return self._stream_prompt(session, content)
@@ -296,8 +301,9 @@ class EmbeddedClient(BaseClient):
 
         try:
             work_dir = Path(session.cwd) if session.cwd else None
-            response = await session.agent.run(
-                user_input=content,
+            response = await self.services.session_service.run(
+                session.agent,
+                content,
                 work_dir=work_dir,
                 stream=False,
                 show_progress=False,
@@ -325,8 +331,9 @@ class EmbeddedClient(BaseClient):
         try:
             work_dir = Path(session.cwd) if session.cwd else None
 
-            response = await session.agent.run(
-                user_input=content,
+            response = await self.services.session_service.run(
+                session.agent,
+                content,
                 work_dir=work_dir,
                 stream=True,
                 show_progress=False,

--- a/src/ankaloop/client/embedded.py
+++ b/src/ankaloop/client/embedded.py
@@ -90,6 +90,7 @@ class EmbeddedClient(BaseClient):
         """Cleanup resources."""
         for session in self._sessions.values():
             await session.agent.close()
+            self.services.session_service.forget(session.agent)
         self._sessions.clear()
         self._connected = False
 
@@ -247,7 +248,7 @@ class EmbeddedClient(BaseClient):
         finally:
             self._sessions.pop(session_id, None)
             self._closing_sessions.discard(session_id)
-            self.services.session_service.forget(session_id)
+            self.services.session_service.forget(session.agent)
 
     # =========================================================================
     # Prompt Operations

--- a/src/ankaloop/config.py
+++ b/src/ankaloop/config.py
@@ -107,6 +107,7 @@ class ChatConfig:
     # Built-in file modification tools
     write_tool_enabled: bool | None = None
     edit_tool_enabled: bool | None = None
+    sync_tool_settle_timeout_seconds: float = 2.0
     # Agent settings
     default_agent: str | None = None  # default agent to use: "coder", "explorer", etc.
     # Queue settings
@@ -256,6 +257,7 @@ _DEFAULT = {
         # "mcp_servers": ["custom"]  # optional; if unset, expose all configured servers
         "write_tool_enabled": True,
         "edit_tool_enabled": True,
+        "sync_tool_settle_timeout_seconds": 2.0,
     },
     "context": {
         "progressive_tools": True,
@@ -424,6 +426,7 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
     mcp_servers = raw.get("mcp_servers")
     write_tool_enabled = raw.get("write_tool_enabled")
     edit_tool_enabled = raw.get("edit_tool_enabled")
+    sync_tool_settle_timeout_seconds = raw.get("sync_tool_settle_timeout_seconds", 2.0)
     # Agent settings
     default_agent = raw.get("default_agent")
     # Queue settings
@@ -460,6 +463,7 @@ def _decode_chat(raw: Mapping[str, object] | None) -> ChatConfig | None:
         mcp_servers=[str(s) for s in mcp_servers] if isinstance(mcp_servers, list) else None,
         write_tool_enabled=bool(write_tool_enabled) if write_tool_enabled is not None else None,
         edit_tool_enabled=bool(edit_tool_enabled) if edit_tool_enabled is not None else None,
+        sync_tool_settle_timeout_seconds=float(str(sync_tool_settle_timeout_seconds)),
         default_agent=str(default_agent) if default_agent is not None else None,
         enable_queue=bool(enable_queue) if enable_queue is not None else None,
         max_queue_size=int(str(max_queue_size)) if max_queue_size is not None else None,
@@ -788,6 +792,7 @@ def _encode_chat(c: ChatConfig | None) -> dict | None:
         out["write_tool_enabled"] = bool(c.write_tool_enabled)
     if c.edit_tool_enabled is not None:
         out["edit_tool_enabled"] = bool(c.edit_tool_enabled)
+    out["sync_tool_settle_timeout_seconds"] = float(c.sync_tool_settle_timeout_seconds)
     # Agent settings
     if c.default_agent:
         out["default_agent"] = c.default_agent

--- a/src/ankaloop/hooks.py
+++ b/src/ankaloop/hooks.py
@@ -281,6 +281,7 @@ class HookHandler:
         function: Python function path (for python type, e.g., "module.function")
         timeout: Timeout in seconds for hook execution
         enabled: Whether this handler is enabled
+        failure_mode: Whether execution failures are allowed ("open") or block ("closed")
         action: Action for markdown hooks - "warn" or "block"
         pattern: Regex pattern for markdown hooks
         message: Message to display (for markdown hooks)
@@ -295,6 +296,7 @@ class HookHandler:
     function: str | None = None
     timeout: int = 30
     enabled: bool = True
+    failure_mode: str = "open"
     # Markdown hook specific fields
     action: str = "warn"  # "warn" or "block"
     pattern: str | None = None
@@ -444,6 +446,10 @@ class HooksManager:
                         function=handler_data.get("function"),
                         timeout=handler_data.get("timeout", 30),
                         enabled=handler_data.get("enabled", True),
+                        failure_mode=self._normalize_failure_mode(
+                            handler_data.get("failure_mode", "open"),
+                            event,
+                        ),
                     )
                     # Resolve relative paths
                     if handler.script and not Path(handler.script).is_absolute():
@@ -453,6 +459,19 @@ class HooksManager:
                         handler.command = handler.command.replace("$ANKA_PROJECT_DIR", str(self.project_dir))
 
                     self.hooks[event].handlers.append(handler)
+
+    @staticmethod
+    def _normalize_failure_mode(value: object, event: HookEvent) -> str:
+        """Validate a configured hook failure mode."""
+        failure_mode = str(value).strip().lower()
+        if failure_mode not in {"open", "closed"}:
+            logger.warning(
+                "Invalid failure_mode %r for %s; defaulting to open",
+                value,
+                event.value,
+            )
+            return "open"
+        return failure_mode
 
     def _load_markdown_hooks_dir(self, hooks_dir: Path) -> None:
         """Load Markdown hook files from a directory.
@@ -626,15 +645,36 @@ class HooksManager:
 
         for handler in handlers:
             try:
-                if handler.type == "command" and handler.command:
-                    output = await self._execute_command_hook(handler, hook_input)
+                if handler.type == "command":
+                    if handler.command:
+                        output = await self._execute_command_hook(handler, hook_input)
+                    else:
+                        output = HookOutput(
+                            success=False,
+                            feedback="Command hook is missing its command",
+                        )
                 elif handler.type == "python":
-                    output = await self._execute_python_hook(handler, hook_input)
+                    if handler.script or handler.function:
+                        output = await self._execute_python_hook(handler, hook_input)
+                    else:
+                        output = HookOutput(
+                            success=False,
+                            feedback="Python hook requires a script or function",
+                        )
                 elif handler.type == "markdown":
                     output = self._execute_markdown_hook(handler, hook_input)
                 else:
-                    logger.warning(f"Unknown hook type: {handler.type}")
-                    continue
+                    output = HookOutput(
+                        success=False,
+                        feedback=f"Unknown hook type: {handler.type}",
+                    )
+
+                if not output.success and handler.failure_mode == "closed":
+                    reason = output.feedback or "Hook execution failed"
+                    output.continue_execution = False
+                    output.stop_reason = reason
+                    output.decision = HookDecision.DENY
+                    output.decision_reason = reason
 
                 # Merge outputs (later hooks can override earlier ones)
                 self._merge_outputs(combined_output, output)
@@ -653,10 +693,26 @@ class HooksManager:
 
             except TimeoutError:
                 logger.warning(f"Hook timed out after {handler.timeout}s")
-                combined_output.feedback = f"Hook timed out after {handler.timeout}s"
+                reason = f"Hook timed out after {handler.timeout}s"
+                combined_output.success = False
+                combined_output.feedback = reason
+                if handler.failure_mode == "closed":
+                    combined_output.continue_execution = False
+                    combined_output.stop_reason = reason
+                    combined_output.decision = HookDecision.DENY
+                    combined_output.decision_reason = reason
+                    break
             except Exception as e:
                 logger.warning(f"Hook execution failed: {e}")
-                combined_output.feedback = f"Hook execution failed: {e}"
+                reason = f"Hook execution failed: {e}"
+                combined_output.success = False
+                combined_output.feedback = reason
+                if handler.failure_mode == "closed":
+                    combined_output.continue_execution = False
+                    combined_output.stop_reason = reason
+                    combined_output.decision = HookDecision.DENY
+                    combined_output.decision_reason = reason
+                    break
 
         return combined_output
 
@@ -910,8 +966,13 @@ class HooksManager:
 
     def _merge_outputs(self, target: HookOutput, source: HookOutput) -> None:
         """Merge source output into target output."""
+        if not source.success:
+            target.success = False
         if source.feedback:
             target.feedback = (target.feedback or "") + "\n" + source.feedback
+        if not source.continue_execution:
+            target.continue_execution = False
+            target.stop_reason = source.stop_reason
         if source.system_message:
             target.system_message = source.system_message
         if source.updated_input:

--- a/src/ankaloop/memory.py
+++ b/src/ankaloop/memory.py
@@ -141,20 +141,25 @@ class MemoryStore:
                 logger.warning(f"Could not read long-term memory: {e}")
         return ""
 
-    def write_long_term(self, content: str) -> None:
+    def write_long_term(self, content: str) -> bool:
         """Write (overwrite) long-term memory.
 
         The agent should curate this to keep it organized and compact.
 
         Args:
             content: New content for MEMORY.md
+
+        Returns:
+            Whether the content was written successfully.
         """
         self._ensure_dir()
         try:
             self.memory_file.write_text(content, encoding="utf-8")
             logger.info(f"Updated long-term memory ({len(content)} chars)")
+            return True
         except Exception as e:
             logger.error(f"Could not write long-term memory: {e}")
+            return False
 
     # --- Soul and Identity ---
 
@@ -649,15 +654,18 @@ class MemoryManager:
         store = self._store_for_scope(scope)
         return store.read_long_term()
 
-    def write_long_term(self, content: str, scope: str = "user") -> None:
+    def write_long_term(self, content: str, scope: str = "user") -> bool:
         """Write long-term memory to the specified scope.
 
         Args:
             content: Memory content
             scope: "user" or "project"
+
+        Returns:
+            Whether the content was written successfully.
         """
         store = self._store_for_scope(scope)
-        store.write_long_term(content)
+        return store.write_long_term(content)
 
     def append_history(
         self,

--- a/src/ankaloop/memory_dream.py
+++ b/src/ankaloop/memory_dream.py
@@ -83,21 +83,50 @@ class MemoryDreamer:
         if len(new_events) < self.min_new_events:
             return DreamRunResult(ran=False, updated=False, reason="not_enough_new_events")
 
-        last_run_at = float(state.get("last_run_at", 0))
-        if time.time() - last_run_at < self.min_interval_seconds:
+        last_attempt_at = max(
+            float(state.get("last_run_at", 0)),
+            float(state.get("last_attempt_at", 0)),
+        )
+        if time.time() - last_attempt_at < self.min_interval_seconds:
             return DreamRunResult(ran=False, updated=False, reason="too_soon")
 
         if not self._acquire_lock():
             return DreamRunResult(ran=False, updated=False, reason="locked")
 
         try:
+            pending_memory = state.get("pending_memory")
+            if isinstance(pending_memory, str) and pending_memory:
+                pending_event_id = int(state.get("pending_event_id", last_event_id))
+                manager = get_memory_manager(self.project_root)
+                if not manager.write_long_term(pending_memory, scope="project"):
+                    state["last_attempt_at"] = time.time()
+                    self._save_state(state)
+                    return DreamRunResult(ran=True, updated=False, reason="write_failed")
+                self._save_state(
+                    {
+                        "last_run_at": time.time(),
+                        "last_event_id": pending_event_id,
+                    }
+                )
+                return DreamRunResult(ran=True, updated=True, reason="updated")
+
             updated_memory = self._consolidate(events)
-            self._save_state({"last_run_at": time.time(), "last_event_id": latest_event_id})
             if not updated_memory:
+                self._save_state({"last_run_at": time.time(), "last_event_id": latest_event_id})
                 return DreamRunResult(ran=True, updated=False, reason="no_reply")
 
             manager = get_memory_manager(self.project_root)
-            manager.write_long_term(updated_memory, scope="project")
+            if not manager.write_long_term(updated_memory, scope="project"):
+                self._save_state(
+                    {
+                        **state,
+                        "last_attempt_at": time.time(),
+                        "pending_memory": updated_memory,
+                        "pending_event_id": latest_event_id,
+                    }
+                )
+                return DreamRunResult(ran=True, updated=False, reason="write_failed")
+            self._save_state({"last_run_at": time.time(), "last_event_id": latest_event_id})
             return DreamRunResult(ran=True, updated=True, reason="updated")
         except Exception as e:
             logger.debug(f"Memory dream failed (non-critical): {e}")

--- a/src/ankaloop/message_queue.py
+++ b/src/ankaloop/message_queue.py
@@ -21,20 +21,13 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+import warnings
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from typing import Any
 
-
-class MessagePriority(Enum):
-    """Priority levels for queued messages."""
-
-    LOW = 0
-    NORMAL = 1
-    HIGH = 2
-    URGENT = 3
+from .runtime import MessagePriority
 
 
 @dataclass
@@ -184,10 +177,10 @@ class SessionQueue:
 
 
 class MessageQueueManager:
-    """Manages message queues for multiple sessions.
+    """Deprecated compatibility queue.
 
-    Provides centralized management of session queues,
-    busy state tracking, and message routing.
+    Production execution is owned by ``SessionRuntime``. This class remains for
+    one compatibility cycle so existing imports do not break.
 
     Example usage:
         manager = MessageQueueManager()
@@ -214,6 +207,11 @@ class MessageQueueManager:
 
     def __init__(self):
         """Initialize the message queue manager."""
+        warnings.warn(
+            "MessageQueueManager is deprecated; submit work through ApplicationSessionService or SessionRuntime",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._session_queues: dict[str, SessionQueue] = {}
         self._busy_sessions: set[str] = set()
         self._session_locks: dict[str, asyncio.Lock] = {}

--- a/src/ankaloop/multi_agent.py
+++ b/src/ankaloop/multi_agent.py
@@ -261,7 +261,11 @@ class AgentRegistry:
         if not parent or not parent.can_delegate:
             return []
 
-        return self.list_subagents()
+        return [
+            name
+            for name, config in self._agents.items()
+            if config.mode == AgentMode.SUBAGENT and (config.parent_agent is None or config.parent_agent == parent_name)
+        ]
 
     def load_from_file(self, config_file: Path) -> None:
         """Load agent configurations from a YAML file.

--- a/src/ankaloop/runtime.py
+++ b/src/ankaloop/runtime.py
@@ -5,16 +5,26 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import heapq
+import logging
 import uuid
 from collections import deque
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from pathlib import Path
 from typing import Any
 
-from .message_queue import MessagePriority
+logger = logging.getLogger(__name__)
+
+
+class MessagePriority(IntEnum):
+    """Priority used by the canonical session runtime."""
+
+    LOW = 0
+    NORMAL = 1
+    HIGH = 2
+    URGENT = 3
 
 
 class TurnStatus(StrEnum):
@@ -68,31 +78,116 @@ class TurnRequest:
 
 
 @dataclass(frozen=True)
+class ErrorEnvelope:
+    """Transport-neutral description of a turn failure."""
+
+    code: str
+    message: str
+    retryable: bool = False
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_exception(cls, error: BaseException) -> ErrorEnvelope:
+        """Build a stable error envelope without depending on provider modules."""
+        kind = getattr(error, "kind", None)
+        kind_value = getattr(kind, "value", None)
+        code = f"PROVIDER_{str(kind_value).upper()}" if kind_value else "AGENT_ERROR"
+        details: dict[str, Any] = {"exception_type": type(error).__name__}
+        status_code = getattr(error, "status_code", None)
+        if status_code is not None:
+            details["status_code"] = status_code
+        return cls(
+            code=code,
+            message=str(error),
+            retryable=bool(getattr(error, "retryable", False)),
+            details=details,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation."""
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
 class TurnResult:
     """Terminal result stored for every turn."""
 
     status: TurnStatus
     value: str | None = None
     error: BaseException | None = None
+    error_envelope: ErrorEnvelope | None = None
+
+    @classmethod
+    def failed(cls, error: BaseException) -> TurnResult:
+        """Create a failed result with its stable public error representation."""
+        return cls(
+            status=TurnStatus.FAILED,
+            error=error,
+            error_envelope=ErrorEnvelope.from_exception(error),
+        )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class TurnEvent:
-    """One observable turn state transition."""
-
-    turn_id: str
-    status: TurnStatus
-    timestamp: datetime = field(default_factory=datetime.now)
-
-
-@dataclass(frozen=True)
-class TurnStreamEvent:
-    """One output or lifecycle event produced by a turn."""
+    """One transport-neutral lifecycle or output event."""
 
     turn_id: str
     type: str
     data: dict[str, Any] = field(default_factory=dict)
+    status: TurnStatus | None = None
     timestamp: datetime = field(default_factory=datetime.now)
+
+    def __init__(
+        self,
+        turn_id: str,
+        event_type: str | TurnStatus | None = None,
+        value: dict[str, Any] | datetime | None = None,
+        *,
+        data: dict[str, Any] | None = None,
+        status: TurnStatus | None = None,
+        timestamp: datetime | None = None,
+        type: str | TurnStatus | None = None,
+    ) -> None:
+        """Accept both legacy lifecycle and stream event constructor shapes."""
+        if event_type is None:
+            event_type = type
+        if event_type is None:
+            raise TypeError("TurnEvent requires an event type or status")
+        if isinstance(event_type, TurnStatus):
+            status = event_type
+            resolved_type = f"turn.{event_type.value}"
+            if isinstance(value, datetime):
+                timestamp = value
+        else:
+            resolved_type = event_type
+            if isinstance(value, dict):
+                data = value
+            elif isinstance(value, datetime):
+                timestamp = value
+        object.__setattr__(self, "turn_id", turn_id)
+        object.__setattr__(self, "type", resolved_type)
+        object.__setattr__(self, "data", dict(data or {}))
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "timestamp", timestamp or datetime.now())
+
+    @classmethod
+    def transition(cls, turn_id: str, status: TurnStatus) -> TurnEvent:
+        """Create a canonical lifecycle transition event."""
+        return cls(
+            turn_id=turn_id,
+            type=f"turn.{status.value}",
+            status=status,
+            data={"turn_status": status.value},
+        )
+
+
+# Compatibility alias for integrations that imported the previous stream-only name.
+TurnStreamEvent = TurnEvent
 
 
 class TurnHandle:
@@ -106,8 +201,10 @@ class TurnHandle:
         self.finished_at: datetime | None = None
         self._completion: asyncio.Future[TurnResult] = asyncio.get_running_loop().create_future()
         self.events: asyncio.Queue[TurnEvent] = asyncio.Queue()
-        self.events.put_nowait(TurnEvent(self.id, TurnStatus.QUEUED))
-        self._stream_subscribers: set[asyncio.Queue[TurnStreamEvent]] = set()
+        self.events.put_nowait(TurnEvent.transition(self.id, TurnStatus.QUEUED))
+        self._stream_subscribers: set[asyncio.Queue[TurnEvent]] = set()
+        self._done_callbacks: list[Callable[[TurnHandle], None]] = []
+        self._event_callbacks: list[Callable[[TurnEvent], None]] = []
 
     @property
     def id(self) -> str:
@@ -138,20 +235,31 @@ class TurnHandle:
         """Cancel this queued or active turn."""
         return await self._runtime.cancel_turn(self.id)
 
-    def subscribe(self, *, max_queue_size: int = 256) -> asyncio.Queue[TurnStreamEvent]:
+    def add_done_callback(self, callback: Callable[[TurnHandle], None]) -> None:
+        """Register a callback invoked once after the terminal result is stored."""
+        if self.done:
+            callback(self)
+            return
+        self._done_callbacks.append(callback)
+
+    def add_event_callback(self, callback: Callable[[TurnEvent], None]) -> None:
+        """Observe future lifecycle transitions without consuming the event queue."""
+        self._event_callbacks.append(callback)
+
+    def subscribe(self, *, max_queue_size: int = 256) -> asyncio.Queue[TurnEvent]:
         """Subscribe to output produced after this call."""
         if max_queue_size < 1:
             raise ValueError("max_queue_size must be positive")
-        queue: asyncio.Queue[TurnStreamEvent] = asyncio.Queue(maxsize=max_queue_size)
+        queue: asyncio.Queue[TurnEvent] = asyncio.Queue(maxsize=max_queue_size)
         self._stream_subscribers.add(queue)
         return queue
 
-    def unsubscribe(self, queue: asyncio.Queue[TurnStreamEvent]) -> None:
+    def unsubscribe(self, queue: asyncio.Queue[TurnEvent]) -> None:
         """Stop an output subscription without affecting turn execution."""
         self._stream_subscribers.discard(queue)
 
     def _publish(self, event_type: str, data: dict[str, Any] | None = None) -> None:
-        event = TurnStreamEvent(self.id, event_type, data or {})
+        event = TurnEvent(self.id, event_type, data=data or {})
         for queue in tuple(self._stream_subscribers):
             try:
                 queue.put_nowait(event)
@@ -160,10 +268,10 @@ class TurnHandle:
                 while not queue.empty():
                     queue.get_nowait()
                 queue.put_nowait(
-                    TurnStreamEvent(
+                    TurnEvent(
                         self.id,
                         "stream.overflow",
-                        {"error": "Turn stream consumer is too slow"},
+                        data={"error": "Turn stream consumer is too slow"},
                     )
                 )
 
@@ -173,10 +281,18 @@ class TurnHandle:
         self._transition(result.status)
         self.finished_at = datetime.now()
         self._completion.set_result(result)
+        callbacks, self._done_callbacks = self._done_callbacks, []
+        for callback in callbacks:
+            with contextlib.suppress(Exception):
+                callback(self)
 
     def _transition(self, status: TurnStatus) -> None:
         self.status = status
-        self.events.put_nowait(TurnEvent(self.id, status))
+        event = TurnEvent.transition(self.id, status)
+        self.events.put_nowait(event)
+        for callback in tuple(self._event_callbacks):
+            with contextlib.suppress(Exception):
+                callback(event)
 
 
 RuntimeProcessor = Callable[[TurnRequest], Coroutine[Any, Any, str]]
@@ -237,6 +353,14 @@ class SessionRuntime:
     def is_closed(self) -> bool:
         """Return whether this runtime permanently stopped accepting work."""
         return self._closed
+
+    def has_pending_work(self, *, excluding: TurnHandle | None = None) -> bool:
+        """Return whether active or queued work remains besides one handle."""
+        active_pending = (
+            self._active_handle is not None and self._active_handle is not excluding and not self._active_handle.done
+        )
+        queued_pending = any(handle is not excluding and not handle.done for _, _, handle in self._queue)
+        return active_pending or queued_pending
 
     def get_turn(self, turn_id: str) -> TurnHandle | None:
         """Return a previously submitted turn."""
@@ -397,7 +521,7 @@ class SessionRuntime:
                 self.status = SessionRuntimeStatus.CANCELLED
                 self._emit("turn.cancelled", handle)
             except BaseException as exc:
-                handle._finish(TurnResult(TurnStatus.FAILED, error=exc))
+                handle._finish(TurnResult.failed(exc))
                 self.status = SessionRuntimeStatus.ERROR
                 self._emit("turn.failed", handle)
             else:
@@ -423,9 +547,18 @@ class SessionRuntime:
             data["response"] = outcome.value
             if outcome.error is not None:
                 data["error"] = str(outcome.error)
+            if outcome.error_envelope is not None:
+                data["error_envelope"] = outcome.error_envelope.to_dict()
         handle._publish(event, data)
         if self._event_callback is not None:
-            self._event_callback(event, handle)
+            try:
+                self._event_callback(event, handle)
+            except Exception:
+                logger.exception(
+                    "Session runtime observer failed for %s on turn %s",
+                    event,
+                    handle.id,
+                )
 
     def publish_turn_event(self, turn_id: str, event_type: str, data: dict[str, Any]) -> None:
         """Publish agent output to subscribers of the active turn."""

--- a/src/ankaloop/runtime.py
+++ b/src/ankaloop/runtime.py
@@ -185,6 +185,16 @@ class TurnEvent:
             data={"turn_status": status.value},
         )
 
+    @classmethod
+    def output(
+        cls,
+        turn_id: str,
+        event_type: str,
+        data: dict[str, Any] | None = None,
+    ) -> TurnEvent:
+        """Create a canonical output event."""
+        return cls(turn_id=turn_id, type=event_type, data=data or {})
+
 
 # Compatibility alias for integrations that imported the previous stream-only name.
 TurnStreamEvent = TurnEvent
@@ -259,7 +269,7 @@ class TurnHandle:
         self._stream_subscribers.discard(queue)
 
     def _publish(self, event_type: str, data: dict[str, Any] | None = None) -> None:
-        event = TurnEvent(self.id, event_type, data=data or {})
+        event = TurnEvent.output(self.id, event_type, data)
         for queue in tuple(self._stream_subscribers):
             try:
                 queue.put_nowait(event)
@@ -268,10 +278,10 @@ class TurnHandle:
                 while not queue.empty():
                     queue.get_nowait()
                 queue.put_nowait(
-                    TurnEvent(
+                    TurnEvent.output(
                         self.id,
                         "stream.overflow",
-                        data={"error": "Turn stream consumer is too slow"},
+                        {"error": "Turn stream consumer is too slow"},
                     )
                 )
 

--- a/src/ankaloop/server/routes/sessions.py
+++ b/src/ankaloop/server/routes/sessions.py
@@ -11,7 +11,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
-from ...llm import ProviderError
+from ...runtime import ErrorEnvelope
 from ..interaction import apply_interaction_result, route_server_interaction
 from ..models import (
     CancelRequest,
@@ -40,28 +40,20 @@ async def _safe_emit(coro: Coroutine[Any, Any, None]) -> None:
         await coro
 
 
-def _queue_priority(priority: str):
-    """Map server API priority strings to the agent queue enum."""
-    from ...message_queue import MessagePriority as QueuePriority
-
-    priority_map = {
-        "low": QueuePriority.LOW,
-        "normal": QueuePriority.NORMAL,
-        "high": QueuePriority.HIGH,
-        "urgent": QueuePriority.URGENT,
-    }
-    return priority_map.get(priority, QueuePriority.NORMAL)
-
-
-async def _enqueue_agent_prompt(session: Any, content: str, request: PromptRequest):
+async def _enqueue_agent_prompt(
+    session_manager: Any,
+    session: Any,
+    content: str,
+    request: PromptRequest,
+):
     """Submit a queued prompt and return its owned turn handle and position."""
     position = session.agent.queued_count() + 1
-    handle = await session.agent.submit(
-        content,
+    handle = await session_manager.submit_prompt(
+        session_id=session.id,
+        content=content,
         work_dir=Path(session.cwd),
         stream=request.stream,
-        show_progress=False,
-        priority=_queue_priority(request.priority.value),
+        priority=request.priority.value,
     )
     return handle, position
 
@@ -205,7 +197,12 @@ async def send_prompt(session_id: str, request: PromptRequest) -> PromptResponse
 
         if is_busy:
             # Default: queue the message
-            handle, position = await _enqueue_agent_prompt(session, routed.content, request)
+            handle, position = await _enqueue_agent_prompt(
+                session_manager,
+                session,
+                routed.content,
+                request,
+            )
 
             # Notify about queuing
             await _safe_emit(
@@ -238,7 +235,6 @@ async def send_prompt(session_id: str, request: PromptRequest) -> PromptResponse
             priority=request.priority.value,
         )
         response_text = await handle.wait()
-        session.message_count += 1
 
         return PromptResponse(
             session_id=session_id,
@@ -329,8 +325,6 @@ async def send_prompt_stream(session_id: str, request: PromptRequest) -> Streami
                 message_id = handle.id
                 async for frame in turn_frames(handle, session_id):
                     yield json.dumps(frame) + "\n"
-                if handle.status.value == "completed":
-                    session.message_count += 1
             else:
                 yield (
                     json.dumps(
@@ -348,15 +342,16 @@ async def send_prompt_stream(session_id: str, request: PromptRequest) -> Streami
                 yield json.dumps({"type": "complete", "turn_id": message_id}) + "\n"
 
         except Exception as e:
-            provider = e if isinstance(e, ProviderError) else None
+            envelope = ErrorEnvelope.from_exception(e)
             yield (
                 json.dumps(
                     {
                         "type": "error",
                         "turn_id": message_id,
-                        "error": str(e),
-                        "code": f"PROVIDER_{provider.kind.value.upper()}" if provider else "AGENT_ERROR",
-                        "retryable": provider.retryable if provider else False,
+                        "error": envelope.message,
+                        "code": envelope.code,
+                        "retryable": envelope.retryable,
+                        "details": envelope.details,
                     }
                 )
                 + "\n"
@@ -401,12 +396,14 @@ async def get_turn(session_id: str, turn_id: str) -> dict[str, Any]:
     if handle is None:
         raise HTTPException(status_code=404, detail={"code": "TURN_NOT_FOUND"})
     outcome = handle.outcome
+    envelope = outcome.error_envelope if outcome else None
     return {
         "session_id": session_id,
         "turn_id": turn_id,
         "status": handle.status.value,
         "response": outcome.value if outcome else None,
         "error": str(outcome.error) if outcome and outcome.error else None,
+        "error_envelope": envelope.to_dict() if envelope else None,
     }
 
 

--- a/src/ankaloop/server/session_manager.py
+++ b/src/ankaloop/server/session_manager.py
@@ -16,6 +16,8 @@ from typing import Any
 from ..agent import Agent
 from ..agent_spec import get_default_agent_spec
 from ..application_services import ApplicationServices
+from ..application_session import ApplicationSessionService
+from ..runtime import TurnEvent, TurnStatus
 from .config import ServerConfig, get_server_config
 from .models import Session, SessionStatus, TokenUsage
 
@@ -61,43 +63,73 @@ class ManagedSession:
         agent: Agent,
         cwd: str,
         agent_name: str,
+        session_service: ApplicationSessionService,
     ):
         self.id = session_id
         self.agent = agent
         self.cwd = cwd
         self.agent_name = agent_name
+        self.session_service = session_service
         self.created_at = datetime.now()
-        self.updated_at = datetime.now()
+        self.metrics = session_service.metrics_for(agent)
         self.status = SessionStatus.IDLE
-        self.message_count = 0
-        self.token_usage = TokenUsage()
 
     def to_session(self) -> Session:
         """Convert to Session model."""
-        self.status = SessionStatus(self.agent.get_queue_status()["status"])
+        runtime_status = self.agent.get_queue_status()["status"]
+        self.status = SessionStatus(runtime_status)
+        metrics = self.session_service.metrics_for(self.agent)
         return Session(
             id=self.id,
             created_at=self.created_at,
-            updated_at=self.updated_at,
+            updated_at=metrics.updated_at or self.created_at,
             cwd=self.cwd,
             agent_name=self.agent_name,
             status=self.status,
-            message_count=self.message_count,
-            token_usage=self.token_usage,
+            message_count=metrics.message_count,
+            token_usage=TokenUsage(
+                prompt_tokens=metrics.prompt_tokens,
+                completion_tokens=metrics.completion_tokens,
+                total_tokens=metrics.total_tokens,
+            ),
             queued_count=self.agent.queued_count(),
         )
 
     def update_status(self, status: SessionStatus) -> None:
         """Update session status."""
         self.status = status
-        self.updated_at = datetime.now()
+        self.metrics.status = status.value
+        self.metrics.updated_at = datetime.now()
 
     def add_token_usage(self, prompt_tokens: int, completion_tokens: int) -> None:
         """Add token usage."""
-        self.token_usage.prompt_tokens += prompt_tokens
-        self.token_usage.completion_tokens += completion_tokens
-        self.token_usage.total_tokens = self.token_usage.prompt_tokens + self.token_usage.completion_tokens
-        self.updated_at = datetime.now()
+        self.metrics.prompt_tokens += prompt_tokens
+        self.metrics.completion_tokens += completion_tokens
+        self.metrics.total_tokens = self.metrics.prompt_tokens + self.metrics.completion_tokens
+        self.metrics.updated_at = datetime.now()
+
+    @property
+    def updated_at(self) -> datetime:
+        """Return the application-managed update time."""
+        return self.metrics.updated_at or self.created_at
+
+    @property
+    def message_count(self) -> int:
+        """Return the number of successfully completed turns."""
+        return self.metrics.message_count
+
+    @message_count.setter
+    def message_count(self, value: int) -> None:
+        self.metrics.message_count = value
+
+    @property
+    def token_usage(self) -> TokenUsage:
+        """Return current token usage in the server response model."""
+        return TokenUsage(
+            prompt_tokens=self.metrics.prompt_tokens,
+            completion_tokens=self.metrics.completion_tokens,
+            total_tokens=self.metrics.total_tokens,
+        )
 
 
 class SessionManager:
@@ -114,6 +146,7 @@ class SessionManager:
     ):
         self.config = config or get_server_config()
         self.services = services or ApplicationServices.default()
+        self.session_service = self.services.session_service
         self._sessions: dict[str, ManagedSession] = {}
         self._lock = asyncio.Lock()
         self._event_listeners: list[Callable[[str, Any], None]] = []
@@ -173,6 +206,7 @@ class SessionManager:
                 agent=agent,
                 cwd=cwd,
                 agent_name=agent_name,
+                session_service=self.session_service,
             )
 
             # Connect Agent events to EventBridge
@@ -277,6 +311,7 @@ class SessionManager:
             session = self._sessions.pop(session_id)
             await session.agent.close()
             session.agent.delete_persisted_session()
+            self.session_service.forget(session_id)
             self._emit_event("session.deleted", {"session_id": session_id})
 
     async def submit_prompt(
@@ -291,21 +326,45 @@ class SessionManager:
     ):
         """Submit a prompt through the session's sole runtime owner."""
         session = await self.get_session(session_id)
-        from ..message_queue import MessagePriority as QueuePriority
-
-        priority_map = {
-            "low": QueuePriority.LOW,
-            "normal": QueuePriority.NORMAL,
-            "high": QueuePriority.HIGH,
-            "urgent": QueuePriority.URGENT,
-        }
-        return await session.agent.submit(
+        return await self.session_service.submit(
+            session.agent,
             content,
             work_dir=work_dir or Path(session.cwd),
             stream=stream,
             show_progress=False,
-            priority=priority_map.get(priority, QueuePriority.NORMAL),
+            priority=priority,
             reject_if_busy=reject_if_busy,
+            on_event=lambda event: self._on_turn_event(session, event),
+        )
+
+    def _on_turn_event(self, session: ManagedSession, event: TurnEvent) -> None:
+        """Project canonical turn lifecycle into server session events."""
+        if event.status == TurnStatus.RUNNING:
+            status = SessionStatus.BUSY
+        elif event.status in {
+            TurnStatus.COMPLETED,
+            TurnStatus.CANCELLED,
+            TurnStatus.FAILED,
+        }:
+            handle = session.agent.get_turn(event.turn_id)
+            if session.agent.has_pending_work(excluding=handle):
+                status = SessionStatus.BUSY
+            elif event.status == TurnStatus.COMPLETED:
+                status = SessionStatus.IDLE
+            elif event.status == TurnStatus.CANCELLED:
+                status = SessionStatus.CANCELLED
+            else:
+                status = SessionStatus.ERROR
+        else:
+            return
+        session.update_status(status)
+        self._emit_event(
+            "session.status_changed",
+            {
+                "session_id": session.id,
+                "status": status.value,
+                "turn_id": event.turn_id,
+            },
         )
 
     async def prompt_session(
@@ -331,7 +390,6 @@ class SessionManager:
         Raises:
             SessionNotFoundError: If session is not found.
         """
-        session = await self.get_session(session_id)
         handle = await self.submit_prompt(
             session_id,
             content,
@@ -339,30 +397,11 @@ class SessionManager:
             stream=stream,
             priority=priority,
         )
-        session.update_status(SessionStatus.BUSY)
-        self._emit_event(
-            "session.status_changed",
-            {"session_id": session_id, "status": SessionStatus.BUSY.value},
-        )
         try:
             yield await handle.wait()
-            session.message_count += 1
-            session.update_status(SessionStatus.IDLE)
-        except asyncio.CancelledError:
-            session.update_status(SessionStatus.CANCELLED)
-            raise
         except Exception as e:
-            session.update_status(SessionStatus.ERROR)
-            self._emit_event(
-                "session.error",
-                {"session_id": session_id, "error": str(e)},
-            )
+            self._emit_event("session.error", {"session_id": session_id, "error": str(e)})
             raise
-        finally:
-            self._emit_event(
-                "session.status_changed",
-                {"session_id": session_id, "status": session.status.value},
-            )
 
     async def cancel_session(self, session_id: str, force: bool = False) -> None:
         """Cancel the current operation in a session.

--- a/src/ankaloop/server/session_manager.py
+++ b/src/ankaloop/server/session_manager.py
@@ -311,7 +311,7 @@ class SessionManager:
             session = self._sessions.pop(session_id)
             await session.agent.close()
             session.agent.delete_persisted_session()
-            self.session_service.forget(session_id)
+            self.session_service.forget(session.agent)
             self._emit_event("session.deleted", {"session_id": session_id})
 
     async def submit_prompt(

--- a/src/ankaloop/server/turn_stream.py
+++ b/src/ankaloop/server/turn_stream.py
@@ -70,7 +70,7 @@ async def turn_frames(handle: TurnHandle, session_id: str) -> AsyncGenerator[dic
                     event_type = "turn.completed"
                 else:
                     event_type = "turn.failed"
-                frame = _event_frame(TurnEvent(handle.id, event_type), handle)
+                frame = _event_frame(TurnEvent.output(handle.id, event_type), handle)
                 assert frame is not None
                 yield frame
                 return

--- a/src/ankaloop/server/turn_stream.py
+++ b/src/ankaloop/server/turn_stream.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from typing import Any
 
-from ..llm import ProviderError
-from ..runtime import TurnHandle, TurnStatus, TurnStreamEvent
+from ..runtime import TurnEvent, TurnHandle, TurnStatus
 
 
-def _event_frame(event: TurnStreamEvent, handle: TurnHandle) -> dict[str, Any] | None:
+def _event_frame(event: TurnEvent, handle: TurnHandle) -> dict[str, Any] | None:
     """Convert an internal turn event to the public streaming schema."""
     base = {"turn_id": event.turn_id}
     if event.type == "message.chunk":
@@ -25,20 +24,18 @@ def _event_frame(event: TurnStreamEvent, handle: TurnHandle) -> dict[str, Any] |
         return {"type": "complete", **base, "status": "completed"}
     if event.type in {"turn.failed", "turn.cancelled"}:
         cancelled = event.type == "turn.cancelled"
-        error = handle.outcome.error if handle.outcome is not None else None
-        provider = error if isinstance(error, ProviderError) else None
+        envelope = handle.outcome.error_envelope if handle.outcome is not None else None
         return {
             "type": "error",
             **base,
-            "error": event.data.get("error") or ("Turn cancelled" if cancelled else "Turn failed"),
-            "code": (
-                "TURN_CANCELLED"
-                if cancelled
-                else f"PROVIDER_{provider.kind.value.upper()}"
-                if provider
-                else "AGENT_ERROR"
+            "error": (
+                envelope.message
+                if envelope
+                else event.data.get("error") or ("Turn cancelled" if cancelled else "Turn failed")
             ),
-            "retryable": provider.retryable if provider else False,
+            "code": "TURN_CANCELLED" if cancelled else envelope.code if envelope else "AGENT_ERROR",
+            "retryable": envelope.retryable if envelope else False,
+            "details": envelope.details if envelope else {},
         }
     if event.type == "stream.overflow":
         return {
@@ -73,7 +70,7 @@ async def turn_frames(handle: TurnHandle, session_id: str) -> AsyncGenerator[dic
                     event_type = "turn.completed"
                 else:
                     event_type = "turn.failed"
-                frame = _event_frame(TurnStreamEvent(handle.id, event_type), handle)
+                frame = _event_frame(TurnEvent(handle.id, event_type), handle)
                 assert frame is not None
                 yield frame
                 return

--- a/src/ankaloop/server/websocket.py
+++ b/src/ankaloop/server/websocket.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
+from ..runtime import ErrorEnvelope
 from .interaction import apply_interaction_result, route_server_interaction
 from .models import EventType
 from .session_manager import SessionNotFoundError, get_session_manager
@@ -446,6 +447,7 @@ async def handle_prompt(websocket: WebSocket, msg_id: str, payload: dict[str, An
     except (WebSocketDisconnect, RuntimeError):
         return
     except Exception as e:
+        envelope = ErrorEnvelope.from_exception(e)
         with contextlib.suppress(Exception):
             await connection_manager.send(
                 websocket,
@@ -453,8 +455,10 @@ async def handle_prompt(websocket: WebSocket, msg_id: str, payload: dict[str, An
                     "type": "error",
                     "id": msg_id,
                     "payload": {
-                        "error": str(e),
-                        "code": "PROMPT_ERROR",
+                        "error": envelope.message,
+                        "code": envelope.code,
+                        "retryable": envelope.retryable,
+                        "details": envelope.details,
                     },
                 },
             )

--- a/src/ankaloop/session_store.py
+++ b/src/ankaloop/session_store.py
@@ -328,6 +328,8 @@ class SessionStore:
         """Delete the persisted session if present."""
         with self._lock:
             try:
-                self.path.unlink(missing_ok=True)
+                self.root.mkdir(parents=True, exist_ok=True)
+                with self.lock_path.open("a+b") as lock_handle, _exclusive_file_lock(lock_handle):
+                    self.path.unlink(missing_ok=True)
             except OSError as exc:
                 raise SessionStoreError(f"Could not delete session {self.session_id}: {exc}") from exc

--- a/src/ankaloop/task.py
+++ b/src/ankaloop/task.py
@@ -460,6 +460,7 @@ class TaskManager:
 
                 try:
                     # Execute the task in the same trusted workspace as its parent.
+                    # Agent.run routes through the shared ApplicationSessionService.
                     envelope = task.envelope
                     assert envelope is not None
                     result = await agent.run(

--- a/src/ankaloop/telegram/bot.py
+++ b/src/ankaloop/telegram/bot.py
@@ -761,6 +761,7 @@ class TelegramBot:
             )
             self._bind_session_memory(message.chat_id, session)
             streaming = self._config.streaming.streaming_enabled
+            # Agent.submit routes through the shared ApplicationSessionService.
             handle = await session.agent.submit(
                 message.text,
                 work_dir=self._work_dir,

--- a/src/ankaloop/telegram/client.py
+++ b/src/ankaloop/telegram/client.py
@@ -76,3 +76,15 @@ class TelegramClient(BaseClient):
             stream=stream,
             priority=priority,
         )
+
+    async def cancel(self, session_id: str, *, force: bool = False) -> None:
+        """Cancel work in an embedded Telegram client session."""
+        await self._embedded.cancel(session_id, force=force)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """List tools exposed by the embedded client."""
+        return await self._embedded.list_tools()
+
+    async def list_agents(self) -> list[dict[str, Any]]:
+        """List agents exposed by the embedded client."""
+        return await self._embedded.list_agents()

--- a/src/ankaloop/tool_execution.py
+++ b/src/ankaloop/tool_execution.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import os
+import queue
 import signal
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +21,89 @@ from .mcp_client import call_mcp_tool
 from .mcp_naming import is_mcp_tool_name
 from .task import TaskManager, TaskTool
 from .tools import ToolRegistry, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class _BoundedDaemonExecutor:
+    """Small daemon worker pool for synchronous tools that cannot be cancelled."""
+
+    def __init__(self, max_workers: int = 8, max_pending: int = 64) -> None:
+        self._jobs: queue.Queue[
+            tuple[
+                asyncio.AbstractEventLoop,
+                asyncio.Future[ToolResult],
+                Callable[[], ToolResult],
+            ]
+        ] = queue.Queue(maxsize=max_pending)
+        for index in range(max_workers):
+            threading.Thread(
+                target=self._worker,
+                name=f"ankaloop-sync-tool-{index}",
+                daemon=True,
+            ).start()
+
+    def submit(self, operation: Callable[[], ToolResult]) -> asyncio.Future[ToolResult]:
+        """Queue an operation without blocking the event loop."""
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[ToolResult] = loop.create_future()
+        try:
+            self._jobs.put_nowait((loop, future, operation))
+        except queue.Full:
+            future.set_result(
+                ToolResult(
+                    success=False,
+                    content="",
+                    error="Synchronous tool executor is saturated",
+                )
+            )
+        return future
+
+    def _worker(self) -> None:
+        while True:
+            loop, future, operation = self._jobs.get()
+            try:
+                result = operation()
+            except BaseException as exc:
+                self._notify(loop, future, error=exc)
+            else:
+                self._notify(loop, future, result=result)
+            finally:
+                self._jobs.task_done()
+
+    @staticmethod
+    def _notify(
+        loop: asyncio.AbstractEventLoop,
+        future: asyncio.Future[ToolResult],
+        *,
+        result: ToolResult | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        def complete() -> None:
+            if future.done():
+                return
+            if error is not None:
+                future.set_exception(error)
+            else:
+                assert result is not None
+                future.set_result(result)
+
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(complete)
+
+
+_sync_executor: _BoundedDaemonExecutor | None = None
+_sync_executor_lock = threading.Lock()
+
+
+def _get_sync_executor() -> _BoundedDaemonExecutor:
+    """Lazily create the bounded executor shared by synchronous tools."""
+    global _sync_executor
+    if _sync_executor is None:
+        with _sync_executor_lock:
+            if _sync_executor is None:
+                _sync_executor = _BoundedDaemonExecutor()
+    return _sync_executor
 
 
 class ToolCallProtocolError(Exception):
@@ -203,32 +291,52 @@ class ToolExecutor:
         return await self._execute_sync_tool(name, args)
 
     async def _execute_sync_tool(self, name: str, arguments: dict[str, Any]) -> ToolResult:
-        """Run a thread-backed tool and settle it before propagating cancellation.
+        """Run a thread-backed tool and briefly settle it after cancellation.
 
         Python cannot stop a thread that has already entered synchronous tool
-        code. Shielding the worker means a cancelled turn waits until any file,
-        memory, or external side effect has reached a known terminal state.
+        code. The settle deadline gives a normal tool time to reach a terminal
+        state without allowing one stuck worker to block session cancellation
+        forever. A worker that exceeds the deadline is detached and logged.
         """
-        task = asyncio.create_task(
-            asyncio.to_thread(self.registry.execute_tool, name, **arguments),
-            name=f"ankaloop-tool-{self.context.turn_id}-{name}",
+        task = _get_sync_executor().submit(
+            partial(self.registry.execute_tool, name, **arguments),
         )
         try:
             return await asyncio.shield(task)
         except asyncio.CancelledError as cancelled:
-            # Repeated cancellation requests must not break the settled
-            # guarantee while the underlying thread can still mutate state.
+            timeout = self.config.chat.sync_tool_settle_timeout_seconds if self.config.chat is not None else 2.0
+            deadline = asyncio.get_running_loop().time() + max(timeout, 0.0)
             while not task.done():
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    break
                 try:
-                    await asyncio.shield(task)
+                    await asyncio.wait_for(asyncio.shield(task), timeout=remaining)
                 except asyncio.CancelledError:
                     continue
+                except TimeoutError:
+                    break
                 except Exception:
                     break
-            if not task.cancelled():
+            if task.done() and not task.cancelled():
                 with contextlib.suppress(Exception):
                     task.result()
+            elif not task.done():
+                logger.error(
+                    "Synchronous tool %s exceeded the %.2fs cancellation settle deadline "
+                    "for turn %s; its worker remains detached",
+                    name,
+                    max(timeout, 0.0),
+                    self.context.turn_id,
+                )
+                task.add_done_callback(self._consume_detached_result)
             raise cancelled
+
+    @staticmethod
+    def _consume_detached_result(task: asyncio.Future[ToolResult]) -> None:
+        """Retrieve a detached worker result so failures remain observed."""
+        with contextlib.suppress(BaseException):
+            task.result()
 
     def prepare_model_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Canonicalize model input before hooks or trusted runtime binding."""

--- a/src/ankaloop/tool_execution.py
+++ b/src/ankaloop/tool_execution.py
@@ -63,6 +63,8 @@ class _BoundedDaemonExecutor:
         while True:
             loop, future, operation = self._jobs.get()
             try:
+                if future.done():
+                    continue
                 result = operation()
             except BaseException as exc:
                 self._notify(loop, future, error=exc)
@@ -324,19 +326,13 @@ class ToolExecutor:
             elif not task.done():
                 logger.error(
                     "Synchronous tool %s exceeded the %.2fs cancellation settle deadline "
-                    "for turn %s; its worker remains detached",
+                    "for turn %s; cancelling it before execution when possible",
                     name,
                     max(timeout, 0.0),
                     self.context.turn_id,
                 )
-                task.add_done_callback(self._consume_detached_result)
+                task.cancel()
             raise cancelled
-
-    @staticmethod
-    def _consume_detached_result(task: asyncio.Future[ToolResult]) -> None:
-        """Retrieve a detached worker result so failures remain observed."""
-        with contextlib.suppress(BaseException):
-            task.result()
 
     def prepare_model_arguments(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Canonicalize model input before hooks or trusted runtime binding."""

--- a/src/ankaloop/tools.py
+++ b/src/ankaloop/tools.py
@@ -1923,7 +1923,10 @@ _default_registry: ToolRegistry | None = None
 _registry_lock: threading.Lock = threading.Lock()
 
 
-def get_tool_registry(enable_write: bool | None = None) -> ToolRegistry:
+def get_tool_registry(
+    enable_write: bool | None = None,
+    enable_apply_patch: bool | None = None,
+) -> ToolRegistry:
     """Get the global tool registry instance."""
     global _default_registry
     if _default_registry is None:
@@ -1941,8 +1944,15 @@ def get_tool_registry(enable_write: bool | None = None) -> ToolRegistry:
                     enable_write = (
                         chat_cfg.write_tool_enabled if chat_cfg and chat_cfg.write_tool_enabled is not None else True
                     )
+                if enable_apply_patch is None:
+                    enable_apply_patch = (
+                        chat_cfg.edit_tool_enabled if chat_cfg and chat_cfg.edit_tool_enabled is not None else True
+                    )
 
-                _default_registry = create_default_tool_registry(enable_write=enable_write)
+                _default_registry = create_default_tool_registry(
+                    enable_write=enable_write,
+                    enable_apply_patch=enable_apply_patch,
+                )
     return _default_registry
 
 

--- a/tests/test_agent_services.py
+++ b/tests/test_agent_services.py
@@ -54,12 +54,21 @@ async def test_application_session_service_owns_completion_metrics(tmp_path):
         agent = Agent(services=services)
     agent.turn_service.process_message = AsyncMock(return_value="done")  # type: ignore[method-assign]
 
-    handle = await services.session_service.submit(agent, "hello", stream=False)
+    handle = await agent.submit("hello", stream=False)
 
     assert await handle.wait() == "done"
     metrics = services.session_service.metrics_for(agent)
     assert metrics.message_count == 1
     assert metrics.status == "idle"
+
+
+def test_application_session_metrics_do_not_collide_for_reused_session_ids(tmp_path):
+    services = _services()
+    with patch("ankaloop.agent.Path.home", return_value=tmp_path):
+        first = Agent(session_id="shared", services=services)
+        second = Agent(session_id="shared", services=services)
+
+    assert services.session_service.metrics_for(first) is not services.session_service.metrics_for(second)
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_services.py
+++ b/tests/test_agent_services.py
@@ -48,6 +48,21 @@ async def test_process_message_compatibility_entry_delegates(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_application_session_service_owns_completion_metrics(tmp_path):
+    services = _services()
+    with patch("ankaloop.agent.Path.home", return_value=tmp_path):
+        agent = Agent(services=services)
+    agent.turn_service.process_message = AsyncMock(return_value="done")  # type: ignore[method-assign]
+
+    handle = await services.session_service.submit(agent, "hello", stream=False)
+
+    assert await handle.wait() == "done"
+    metrics = services.session_service.metrics_for(agent)
+    assert metrics.message_count == 1
+    assert metrics.status == "idle"
+
+
+@pytest.mark.asyncio
 async def test_context_and_tool_loop_compatibility_entries_delegate(tmp_path):
     with patch("ankaloop.agent.Path.home", return_value=tmp_path):
         agent = Agent(services=_services())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -312,6 +312,18 @@ class TestEmbeddedClient:
         assert client.is_connected is False
 
     @pytest.mark.asyncio
+    async def test_close_forgets_session_metrics(self):
+        """Closing a reusable client releases projections for all removed sessions."""
+        client = EmbeddedClient()
+        await client.connect()
+        await client.create_session(session_id="close-metrics")
+
+        assert len(client.services.session_service._metrics) == 1
+        await client.close()
+
+        assert len(client.services.session_service._metrics) == 0
+
+    @pytest.mark.asyncio
     async def test_context_manager(self):
         """Test async context manager."""
         async with EmbeddedClient() as client:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,6 +25,7 @@ from ankaloop.client.exceptions import (
     SessionNotFoundError,
     TimeoutError,
 )
+from ankaloop.telegram.client import TelegramClient
 
 # ============================================================================
 # Test Exceptions
@@ -141,6 +142,11 @@ class TestAnkaloopClient:
 
         without_url = AnkaloopClient()
         assert without_url.mode == ClientMode.EMBEDDED
+
+    def test_telegram_client_implements_base_client_contract(self):
+        client = TelegramClient(AsyncMock())
+
+        assert isinstance(client, BaseClient)
 
 
 # ============================================================================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,17 +63,20 @@ def test_decode_encode_chat_tool_limits_roundtrip():
         "tool_loop_limit": 300,
         "bash_tool_limit": 100,
         "default_max_lines": 400,
+        "sync_tool_settle_timeout_seconds": 0.75,
     }
 
     cfg = config_module._decode_chat(raw)
     assert cfg is not None
     assert cfg.tool_loop_limit == 300
     assert cfg.bash_tool_limit == 100
+    assert cfg.sync_tool_settle_timeout_seconds == 0.75
 
     encoded = config_module._encode_chat(cfg)
     assert encoded is not None
     assert encoded["tool_loop_limit"] == 300
     assert encoded["bash_tool_limit"] == 100
+    assert encoded["sync_tool_settle_timeout_seconds"] == 0.75
 
 
 def test_decode_encode_provider_reliability_policy_roundtrip():

--- a/tests/test_execution_boundaries.py
+++ b/tests/test_execution_boundaries.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ankaloop import tool_execution as tool_execution_module
 from ankaloop.agent import Agent
 from ankaloop.agent_spec import ResolvedAgentSpec
 from ankaloop.config import AnkaloopConfig, ChatConfig, ContextConfig, Server
@@ -21,6 +22,7 @@ from ankaloop.tool_execution import (
     ToolExecutionContext,
     ToolExecutor,
     WorkspaceBoundaryError,
+    _BoundedDaemonExecutor,
     normalize_tool_calls,
 )
 from ankaloop.tools import create_default_tool_registry
@@ -346,6 +348,54 @@ async def test_thread_backed_tool_cancellation_has_settle_deadline(tmp_path):
     assert not release.is_set()
     release.set()
     await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_queued_sync_tool_is_not_executed(tmp_path):
+    first_started = threading.Event()
+    release_first = threading.Event()
+    queued_executed = threading.Event()
+    registry = MagicMock()
+
+    def execute_tool(name, **_arguments):
+        if name == "blocking_tool":
+            first_started.set()
+            release_first.wait(timeout=5)
+        else:
+            queued_executed.set()
+        return SimpleNamespace(success=True, content=name)
+
+    registry.execute_tool.side_effect = execute_tool
+    executor = ToolExecutor(
+        context=ToolExecutionContext("session", tmp_path, "queued-cancel"),
+        capability=ToolCapability.from_spec(None, [], True),
+        exposed_tools={"blocking_tool", "queued_tool"},
+        registry=registry,
+        mcp_registry={},
+        config=AnkaloopConfig(
+            servers={},
+            chat=ChatConfig(sync_tool_settle_timeout_seconds=0.01),
+        ),
+    )
+
+    with patch.object(
+        tool_execution_module,
+        "_sync_executor",
+        _BoundedDaemonExecutor(max_workers=1, max_pending=2),
+    ):
+        blocking = asyncio.create_task(executor.execute("blocking_tool", {}))
+        assert await asyncio.to_thread(first_started.wait, 1)
+        queued = asyncio.create_task(executor.execute("queued_tool", {}))
+        await asyncio.sleep(0)
+        queued.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await queued
+
+        release_first.set()
+        assert (await blocking).content == "blocking_tool"
+        await asyncio.sleep(0.05)
+
+    assert not queued_executed.is_set()
 
 
 class _ToolCallingLLM:

--- a/tests/test_execution_boundaries.py
+++ b/tests/test_execution_boundaries.py
@@ -12,7 +12,7 @@ import pytest
 
 from ankaloop.agent import Agent
 from ankaloop.agent_spec import ResolvedAgentSpec
-from ankaloop.config import AnkaloopConfig, ContextConfig, Server
+from ankaloop.config import AnkaloopConfig, ChatConfig, ContextConfig, Server
 from ankaloop.multi_agent import AgentMode
 from ankaloop.task import TaskManager
 from ankaloop.tool_execution import (
@@ -312,6 +312,40 @@ async def test_thread_backed_tool_settles_before_cancellation_returns(tmp_path):
     release.set()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_thread_backed_tool_cancellation_has_settle_deadline(tmp_path):
+    started = threading.Event()
+    release = threading.Event()
+    registry = MagicMock()
+
+    def execute_tool(_name, **_arguments):
+        started.set()
+        release.wait(timeout=5)
+        return SimpleNamespace(success=True, content="late")
+
+    registry.execute_tool.side_effect = execute_tool
+    executor = ToolExecutor(
+        context=ToolExecutionContext("session", tmp_path, "deadline"),
+        capability=ToolCapability.from_spec(None, [], True),
+        exposed_tools={"stuck_tool"},
+        registry=registry,
+        mcp_registry={},
+        config=AnkaloopConfig(
+            servers={},
+            chat=ChatConfig(sync_tool_settle_timeout_seconds=0.05),
+        ),
+    )
+
+    task = asyncio.create_task(executor.execute("stuck_tool", {}))
+    assert await asyncio.to_thread(started.wait, 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=0.5)
+    assert not release.is_set()
+    release.set()
+    await asyncio.sleep(0.05)
 
 
 class _ToolCallingLLM:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from ankaloop.hooks import (
+    HookConfig,
     HookDecision,
     HookEvent,
     HookHandler,
@@ -170,6 +171,40 @@ class TestHooksManager:
     def setup_method(self):
         """Reset hooks manager before each test."""
         reset_hooks_manager()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("failure_mode", "continues"),
+        [("open", True), ("closed", False)],
+    )
+    async def test_hook_failure_mode_is_explicit(self, tmp_path, failure_mode, continues):
+        manager = HooksManager(tmp_path)
+        manager._loaded = True
+        manager.hooks[HookEvent.PRE_TOOL_USE] = HookConfig(
+            handlers=[
+                HookHandler(
+                    type="python",
+                    function="missing.module",
+                    failure_mode=failure_mode,
+                )
+            ]
+        )
+
+        output = await manager.execute_hooks(
+            HookEvent.PRE_TOOL_USE,
+            HookInput(
+                session_id="test",
+                hook_event_name="PreToolUse",
+                cwd=str(tmp_path),
+                tool_name="bash",
+                tool_input={"command": "true"},
+            ),
+            "bash",
+        )
+
+        assert output.continue_execution is continues
+        if failure_mode == "closed":
+            assert output.decision == HookDecision.DENY
 
     def test_load_toml_config(self):
         """Test loading hooks from TOML config."""

--- a/tests/test_memory_dream.py
+++ b/tests/test_memory_dream.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from ankaloop.memory import get_memory_manager, reset_memory_manager
 from ankaloop.memory_dream import MemoryDreamer
@@ -53,4 +54,33 @@ def test_memory_dreamer_skips_until_enough_events(tmp_path):
 
     assert result.ran is False
     assert result.reason == "not_enough_new_events"
+    reset_memory_manager()
+
+
+def test_memory_dreamer_does_not_advance_cursor_when_memory_write_fails(tmp_path):
+    reset_memory_manager()
+    manager = get_memory_manager(tmp_path)
+    manager.append_history("first", session_id="s1", scope="project")
+    manager.append_history("second", session_id="s1", scope="project")
+    dreamer = MemoryDreamer(
+        tmp_path,
+        min_interval_seconds=0,
+        min_new_events=2,
+        client=_FakeClient("# Memory\n- consolidated"),
+        model="test-model",
+    )
+
+    with patch.object(manager, "write_long_term", return_value=False):
+        result = dreamer.run_once()
+
+    assert result.reason == "write_failed"
+    state = dreamer._load_state()
+    assert state.get("last_event_id", 0) == 0
+    assert state["pending_event_id"] > 0
+    assert state["pending_memory"] == "# Memory\n- consolidated"
+
+    result = dreamer.run_once()
+
+    assert result.updated is True
+    assert len(dreamer._client.calls) == 1
     reset_memory_manager()

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -215,6 +215,21 @@ class TestAgentRegistry:
         subagents = registry.get_subagents_for("explorer")
         assert subagents == []
 
+    def test_parent_scoped_subagent_is_not_exposed_to_other_parents(self):
+        registry = AgentRegistry()
+        registry.register(
+            AgentConfig(
+                name="coder-only",
+                mode=AgentMode.SUBAGENT,
+                description="Scoped",
+                system_prompt="Scoped",
+                parent_agent="coder",
+            )
+        )
+
+        assert "coder-only" in registry.get_subagents_for("coder")
+        assert "coder-only" not in registry.get_subagents_for("default")
+
 
 class TestGlobalFunctions:
     """Tests for global helper functions."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -275,3 +275,42 @@ async def test_closing_turn_relay_unsubscribes_without_cancelling_turn():
 
     release.set()
     assert await handle.wait() == "result"
+
+
+@pytest.mark.asyncio
+async def test_observer_failure_cannot_strand_runtime_work():
+    observed = []
+
+    async def process(request):
+        return request.prompt
+
+    def broken_observer(event, handle):
+        observed.append((event, handle.id))
+        raise RuntimeError("observer failed")
+
+    runtime = SessionRuntime("observer", process, broken_observer)
+    first = await runtime.submit("first")
+    second = await runtime.submit("second")
+
+    assert await first.wait() == "first"
+    assert await second.wait() == "second"
+    assert first.status == TurnStatus.COMPLETED
+    assert second.status == TurnStatus.COMPLETED
+    assert observed
+
+
+@pytest.mark.asyncio
+async def test_failed_turn_has_stable_error_envelope():
+    async def process(_request):
+        raise ValueError("bad turn")
+
+    runtime = SessionRuntime("errors", process)
+    handle = await runtime.submit("fail")
+
+    with pytest.raises(ValueError, match="bad turn"):
+        await handle.wait()
+
+    assert handle.outcome is not None
+    assert handle.outcome.error_envelope is not None
+    assert handle.outcome.error_envelope.code == "AGENT_ERROR"
+    assert handle.outcome.error_envelope.details["exception_type"] == "ValueError"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -339,7 +339,7 @@ class TestSessionEndpoints:
         handle = MagicMock(id="turn-queued")
         managed.agent.is_busy = MagicMock(return_value=True)
         managed.agent.queued_count = MagicMock(return_value=0)
-        managed.agent.submit = AsyncMock(return_value=handle)
+        managed.agent._submit_turn = AsyncMock(return_value=handle)
 
         response = client.post(
             f"/api/v1/sessions/{session_id}/prompt",
@@ -351,7 +351,7 @@ class TestSessionEndpoints:
         assert data["status"] == "queued"
         assert data["position"] == 1
         assert data["message_id"] == "turn-queued"
-        managed.agent.submit.assert_awaited_once()
+        managed.agent._submit_turn.assert_awaited_once()
 
 
 class TestToolEndpoints:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -134,6 +134,18 @@ def test_stale_session_owner_cannot_overwrite_newer_revision(tmp_path):
     assert [turn.turn_id for turn in persisted.turns] == ["first"]
 
 
+def test_delete_uses_same_cross_process_lock_as_save(tmp_path):
+    store = SessionStore(tmp_path, "delete-lock")
+    store.save(SessionState(session_id="delete-lock", agent_name="test").to_snapshot())
+
+    with patch("ankaloop.session_store._exclusive_file_lock") as lock:
+        lock.return_value.__enter__.return_value = None
+        store.delete()
+
+    lock.assert_called_once()
+    assert not store.path.exists()
+
+
 def test_corrupt_session_has_explicit_diagnostic(tmp_path):
     store = SessionStore(tmp_path, "corrupt")
     store.path.write_text("{not-json", encoding="utf-8")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,6 +2,8 @@ import json
 import re
 from unittest.mock import patch
 
+from ankaloop import tools as tools_module
+from ankaloop.config import AnkaloopConfig, ChatConfig
 from ankaloop.tools import (
     BashTool,
     GrepTool,
@@ -83,6 +85,21 @@ def test_registry_reports_unbindable_arguments_without_raw_typeerror():
     assert result.error.startswith("Invalid arguments:")
     assert "Did you mean 'paths'?" in result.error
     assert "TypeError" not in result.error
+
+
+def test_edit_tool_enabled_controls_apply_patch_registry():
+    cfg = AnkaloopConfig(
+        servers={},
+        chat=ChatConfig(write_tool_enabled=True, edit_tool_enabled=False),
+    )
+    with (
+        patch.object(tools_module, "_default_registry", None),
+        patch("ankaloop.config.load_config", return_value=cfg),
+    ):
+        registry = get_tool_registry()
+
+    assert "write_file" in registry.list_tools()
+    assert "apply_patch" not in registry.list_tools()
 
 
 def test_web_search_tool_firecrawl_backend():


### PR DESCRIPTION
# Pull Request

## Description

Unify AnkaLoop's application session lifecycle around `ApplicationSessionService` and canonical turn contracts.

- centralize turn submission, status, usage, and message-count projection across CLI, server, embedded, Telegram, and delegated-task entry points
- add canonical `TurnEvent`, `TurnResult`, and `ErrorEnvelope` contracts while retaining compatibility aliases
- harden observer isolation, synchronous-tool cancellation, memory-dream persistence, session locking, parent-agent authorization, and hook failure policy
- enforce `edit_tool_enabled`, complete the Telegram client contract, and deprecate the duplicate message-queue scheduler
- consolidate pytest configuration with correct package and branch coverage settings

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have updated `CHANGELOG.md` under **Unreleased** for user-facing changes
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (N/A, no dependent changes)

## Testing

```bash
ruff format src tests
ruff check src tests
mypy src/ankaloop --ignore-missing-imports
python -m pytest -q -m "not llm"
```

Results: 979 passed, 79 warnings, 66% branch coverage. The warnings include existing resource and dependency deprecation warnings plus the intentional `message_queue` deprecation warning.

## Related Issues

N/A
